### PR TITLE
Adding more metadata and cleanup stdout

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -19,26 +19,31 @@ const ltcyMetric = "usec"
 
 // Doc struct of the JSON document to be indexed
 type Doc struct {
-	UUID           string           `json:"uuid"`
-	Timestamp      time.Time        `json:"timestamp"`
-	HostNetwork    bool             `json:"hostNetwork"`
-	Driver         string           `json:"driver"`
-	Parallelism    int              `json:"parallelism"`
-	Profile        string           `json:"profile"`
-	Duration       int              `json:"duration"`
-	Samples        int              `json:"samples"`
-	Messagesize    int              `json:"messageSize"`
-	Throughput     float64          `json:"throughput"`
-	Latency        float64          `json:"latency"`
-	TputMetric     string           `json:"tputMetric"`
-	LtcyMetric     string           `json:"ltcyMetric"`
-	TCPRetransmit  float64          `json:"TCPRetransmits"`
-	UDPLossPercent float64          `json:"UDPLossPercent"`
-	Metadata       result.Metadata  `json:"metadata"`
-	ServerNodeCPU  metrics.NodeCPU  `json:"serverCPU"`
-	ServerPodCPU   []metrics.PodCPU `json:"serverPods"`
-	ClientNodeCPU  metrics.NodeCPU  `json:"clientCPU"`
-	ClientPodCPU   []metrics.PodCPU `json:"clientPods"`
+	UUID             string            `json:"uuid"`
+	Timestamp        time.Time         `json:"timestamp"`
+	HostNetwork      bool              `json:"hostNetwork"`
+	Driver           string            `json:"driver"`
+	Parallelism      int               `json:"parallelism"`
+	Profile          string            `json:"profile"`
+	Duration         int               `json:"duration"`
+	Local            bool              `json:"local"`
+	AcrossAZ         bool              `json:"acrossAZ"`
+	Samples          int               `json:"samples"`
+	MTU              int               `json:"mtu"`
+	Messagesize      int               `json:"messageSize"`
+	Throughput       float64           `json:"throughput"`
+	Latency          float64           `json:"latency"`
+	TputMetric       string            `json:"tputMetric"`
+	LtcyMetric       string            `json:"ltcyMetric"`
+	TCPRetransmit    float64           `json:"tcpRetransmits"`
+	UDPLossPercent   float64           `json:"udpLossPercent"`
+	Metadata         result.Metadata   `json:"metadata"`
+	ServerNodeCPU    metrics.NodeCPU   `json:"serverCPU"`
+	ServerPodCPU     []metrics.PodCPU  `json:"serverPods"`
+	ClientNodeCPU    metrics.NodeCPU   `json:"clientCPU"`
+	ClientPodCPU     []metrics.PodCPU  `json:"clientPods"`
+	ClientNodeLabels map[string]string `json:"clientNodeLabels"`
+	ServerNodeLabels map[string]string `json:"serverNodeLabels"`
 }
 
 // Connect returns a client connected to the desired cluster.
@@ -59,7 +64,7 @@ func Connect(url, index string, skip bool) (*indexers.Indexer, error) {
 		logging.Errorf("%v indexer: %v", indexerConfig.Type, err.Error())
 		return nil, fmt.Errorf("Failure while connnecting to Opensearch")
 	}
-	logging.Infof("Connected to : %s\n", url)
+	logging.Infof("Connected to : %s ", url)
 	return indexer, nil
 }
 
@@ -76,22 +81,25 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 			continue
 		}
 		d := Doc{
-			UUID:          uuid,
-			Timestamp:     time,
-			Driver:        r.Driver,
-			HostNetwork:   r.HostNetwork,
-			Parallelism:   r.Parallelism,
-			Profile:       r.Profile,
-			Duration:      r.Duration,
-			Samples:       r.Samples,
-			Messagesize:   r.MessageSize,
-			TputMetric:    r.Metric,
-			LtcyMetric:    ltcyMetric,
-			ServerNodeCPU: r.ServerMetrics,
-			ClientNodeCPU: r.ClientMetrics,
-			ServerPodCPU:  r.ServerPodCPU.Results,
-			ClientPodCPU:  r.ClientPodCPU.Results,
-			Metadata:      sr.Metadata,
+			UUID:             uuid,
+			Timestamp:        time,
+			Driver:           r.Driver,
+			HostNetwork:      r.HostNetwork,
+			Parallelism:      r.Parallelism,
+			Profile:          r.Profile,
+			Duration:         r.Duration,
+			Samples:          r.Samples,
+			Messagesize:      r.MessageSize,
+			TputMetric:       r.Metric,
+			LtcyMetric:       ltcyMetric,
+			ServerNodeCPU:    r.ServerMetrics,
+			ClientNodeCPU:    r.ClientMetrics,
+			ServerPodCPU:     r.ServerPodCPU.Results,
+			ClientPodCPU:     r.ClientPodCPU.Results,
+			Metadata:         sr.Metadata,
+			ServerNodeLabels: r.ServerNodeLabels,
+			ClientNodeLabels: r.ClientNodeLabels,
+			AcrossAZ:         r.AcrossAZ,
 		}
 		d.UDPLossPercent, _ = result.Average(r.LossSummary)
 		d.TCPRetransmit, _ = result.Average(r.RetransmitSummary)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	MessageSize int    `yaml:"messagesize,omitempty"`
 	Service     bool   `default:"false" yaml:"service,omitempty"`
 	Metric      string
+	AcrossAZ    bool
 }
 
 // PerfScenarios describes the different scenarios
@@ -50,7 +51,7 @@ const validTests = "tcp_stream|udp_stream|tcp_rr|udp_rr|tcp_crr|udp_crr|sctp_str
 // describes which tests to run
 // Returns Config struct
 func ParseConf(fn string) ([]Config, error) {
-	log.Infof("📒 Reading %s file.\n", fn)
+	log.Infof("📒 Reading %s file. ", fn)
 	buf, err := ioutil.ReadFile(fn)
 	if err != nil {
 		return nil, err
@@ -93,5 +94,5 @@ func ParseConf(fn string) ([]Config, error) {
 
 // Show Display the netperf config
 func Show(c Config, driver string) {
-	log.Infof("🗒️  Running %s %s (service %t) for %ds\n", driver, c.Profile, c.Service, c.Duration)
+	log.Infof("🗒️  Running %s %s (service %t) for %ds ", driver, c.Profile, c.Service, c.Duration)
 }

--- a/pkg/iperf/iperf.go
+++ b/pkg/iperf/iperf.go
@@ -55,7 +55,7 @@ func Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1
 	id := uuid.New()
 	file := fmt.Sprintf("/tmp/iperf-%s", id.String())
 	pod := client.Items[0]
-	log.Debugf("🔥 Client (%s,%s) starting iperf3 against server : %s\n", pod.Name, pod.Status.PodIP, serverIP)
+	log.Debugf("🔥 Client (%s,%s) starting iperf3 against server : %s", pod.Name, pod.Status.PodIP, serverIP)
 	config.Show(nc, workload)
 	tcp := true
 	if !strings.Contains(nc.Profile, "STREAM") {

--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -18,6 +18,7 @@ import (
 type NodeInfo struct {
 	IP       string
 	Hostname string
+	NodeName string
 }
 
 // NodeCPU stores CPU information for a specific Node

--- a/pkg/netperf/netperf.go
+++ b/pkg/netperf/netperf.go
@@ -31,7 +31,7 @@ const omniOptions = "rt_latency,p99_latency,throughput,throughput_units,remote_r
 func Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1.PodList, serverIP string) (bytes.Buffer, error) {
 	var stdout, stderr bytes.Buffer
 	pod := client.Items[0]
-	log.Debugf("🔥 Client (%s,%s) starting netperf against server : %s\n", pod.Name, pod.Status.PodIP, serverIP)
+	log.Debugf("🔥 Client (%s,%s) starting netperf against server : %s", pod.Name, pod.Status.PodIP, serverIP)
 	config.Show(nc, workload)
 	var cmd []string
 	if nc.Service {


### PR DESCRIPTION
- Adding node labels to metadata
- Cleanup `\r\n`s from code
- add when workload is running across AZ (due to lack of worker nodes in a single AZ)
- Fix comparison logic to only compare with a single stream, and report

fixes #87
