### PR TITLE
Add short version to metadata

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -29,7 +29,6 @@ type Doc struct {
 	Local            bool              `json:"local"`
 	AcrossAZ         bool              `json:"acrossAZ"`
 	Samples          int               `json:"samples"`
-	MTU              int               `json:"mtu"`
 	Messagesize      int               `json:"messageSize"`
 	Throughput       float64           `json:"throughput"`
 	Latency          float64           `json:"latency"`

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -55,12 +55,13 @@ type ScenarioResults struct {
 
 // Metadata for the run
 type Metadata struct {
-	Platform   string `json:"platform"`
-	Kernel     string `json:"kernel"`
-	Kubelet    string `json:"kubelet"`
-	OCPVersion string `json:"ocpVersion"`
-	IPsec      bool   `json:"ipsec"`
-	MTU        int    `json:"mtu"`
+	Platform        string `json:"platform"`
+	Kernel          string `json:"kernel"`
+	Kubelet         string `json:"kubelet"`
+	OCPVersion      string `json:"ocpVersion"`
+	OCPShortVersion string `json:"ocpShortVersion"`
+	IPsec           bool   `json:"ipsec"`
+	MTU             int    `json:"mtu"`
 }
 
 // Average accepts array of floats to calculate average


### PR DESCRIPTION
Current version includes the nightly information. This PR is to cut down on the unique nightly string and just have the version number.
