### PR TITLE
Metadata cleanup from integration with go-commons

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -193,11 +193,9 @@ var rootCmd = &cobra.Command{
 
 		node := metrics.NodeDetails(pcon)
 		sr.Metadata.Kernel = node.Metric.Kernel
-		sr.Metadata.OCPVersion = metrics.OCPversion(pcon, fTime, lTime)
 		shortReg, _ := regexp.Compile(`([0-9]\.[0-9]+)-*`)
 		short := shortReg.FindString(sr.Metadata.OCPVersion)
 		sr.Metadata.OCPShortVersion = short
-		sr.Metadata.Platform = metrics.Platform(pcon)
 		sec, err := metrics.IPSecEnabled(pcon, fTime, lTime)
 		if err == nil {
 			sr.Metadata.IPsec = sec

--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -107,58 +107,6 @@ func NodeDetails(conn PromConnect) Details {
 	return pd
 }
 
-// Platform returns the platform
-func Platform(conn PromConnect) string {
-	type Data struct {
-		Metric struct {
-			Platform string `json:"type"`
-		}
-	}
-	pd := Data{}
-	if !conn.OpenShift {
-		logging.Warn("Not able to collect OpenShift Specific version info")
-		return ""
-	}
-	query := `cluster_infrastructure_provider`
-	value, err := conn.Client.Query(query, time.Now())
-	if err != nil {
-		logging.Error("Issue querying Prometheus")
-		return ""
-	}
-	status := unmarshalVector(value, &pd)
-	if !status {
-		logging.Error("cannot unmarshal prom query")
-	}
-	return pd.Metric.Platform
-
-}
-
-// OCPversion returns the Cluster version
-func OCPversion(conn PromConnect, start time.Time, end time.Time) string {
-	type Data struct {
-		Metric struct {
-			Version string `json:"version"`
-		}
-	}
-	vd := Data{}
-	ver := ""
-	if !conn.OpenShift {
-		logging.Warn("Not able to collect OpenShift Specific version info")
-		return ver
-	}
-	query := `cluster_version{type="current"}`
-	value, err := conn.Client.Query(query, time.Now())
-	if err != nil {
-		logging.Error("Issue querying Prometheus")
-		return ver
-	}
-	status := unmarshalVector(value, &vd)
-	if !status {
-		logging.Error("Cannot unmarshal the OCP Cluster information")
-	}
-	return vd.Metric.Version
-}
-
 // NodeMTU return mtu
 func NodeMTU(conn PromConnect) (int, error) {
 	if !conn.OpenShift {

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -57,10 +57,7 @@ type ScenarioResults struct {
 // Metadata for the run
 type Metadata struct {
 	ocpmeta.ClusterMetadata
-	Platform        string `json:"platform"`
 	Kernel          string `json:"kernel"`
-	Kubelet         string `json:"kubelet"`
-	OCPVersion      string `json:"ocpVersion"`
 	OCPShortVersion string `json:"ocpShortVersion"`
 	IPsec           bool   `json:"ipsec"`
 	MTU             int    `json:"mtu"`


### PR DESCRIPTION
go-commons provides metadata k8s-netperf was capturing. We should favor the common lib versus using the functions in k8s-netperf

