### PR TITLE
No zone logic problem

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -135,11 +135,7 @@ var rootCmd = &cobra.Command{
 
 		var sr result.ScenarioResults
 		// If the client and server needs to be across zones
-		lz, zones, err := k8s.GetZone(client)
-		if err != nil {
-			log.Error(err)
-			os.Exit(1)
-		}
+		lz, zones, _ := k8s.GetZone(client)
 		nodesInZone := zones[lz]
 		var acrossAZ bool
 		if nodesInZone > 1 {

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -72,7 +72,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	if numNodes > 1 {
 		log.Infof("Deploying in %s zone", z)
 	} else {
-		log.Warn("⚠️  Single node per zone")
+		log.Warn("⚠️  Single node per zone and/or no zone labels")
 	}
 	if len(zones) < 2 && s.AcrossAZ {
 		return fmt.Errorf(" unable to run AcrossAZ since there is < 2 zones")


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Some installs of k8s will not have zone labels. Do not error out due to the lack of zones unless the user passes `--across`


## Related Tickets & Documents

- Related Issue #100
- Closes #100 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
