### PR TITLE
Adding simple retry for empty value

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -385,7 +385,17 @@ func executeWorkload(nc config.Config, s config.PerfScenarios, hostNet bool, ipe
 			nr, err = netperf.ParseResults(&r)
 			if err != nil {
 				log.Error(err)
-				os.Exit(1)
+				log.Warn("Rerunning test.")
+				r, err := netperf.Run(s.ClientSet, s.RestConfig, nc, Client, serverIP)
+				if err != nil {
+					log.Error(err)
+					os.Exit(1)
+				}
+				nr, err = netperf.ParseResults(&r)
+				if err != nil {
+					log.Error(err)
+					os.Exit(1)
+				}
 			}
 		}
 		npr.LossSummary = append(npr.LossSummary, float64(nr.LossPercent))

--- a/pkg/netperf/netperf.go
+++ b/pkg/netperf/netperf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -113,6 +114,9 @@ func ParseResults(stdout *bytes.Buffer) (sample.Sample, error) {
 		} else if strings.Contains(l[0], "LOCAL_TRANSPORT_RETRANS") {
 			sample.Retransmits, _ = strconv.ParseFloat(strings.Trim(l[1], "\r"), 64)
 		}
+	}
+	if math.IsNaN(sample.Throughput) {
+		return sample, fmt.Errorf("Throughput value is NaN")
 	}
 	sample.LossPercent = 100 - (recv / send * 100)
 	return sample, nil


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We are seeing `NaN` in some CI runs. This is due to no output from netperf. This change makes a second attempt in the event the parsing fails to succeed.

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
