### PR TITLE
Update the pod2svc super-netperf argument

### DIFF
--- a/pkg/netperf/netperf.go
+++ b/pkg/netperf/netperf.go
@@ -43,7 +43,7 @@ func Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1
 			"--",
 			"-k", fmt.Sprint(omniOptions),
 			"-m", fmt.Sprint(nc.MessageSize),
-			"-P", fmt.Sprint(ServerDataPort),
+			"-p", fmt.Sprint(ServerDataPort),
 			"-R", "1"}
 	} else {
 		cmd = []string{"bash", "super-netperf", strconv.Itoa(nc.Parallelism), "-H",


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Setting the right argument shorthand
```
-p portnum,locport (*)
Direct the control connection to a netserver listening on the specified port, rather than using a "netperf" entry in /etc/services or the internal default (port 12865). If ",locport" is specified the control connection will be established from that local port number. Specifying a single port number with no comma will specify only the remote netserver port number and will leave local port number selection to the stack.
-P 0|1
Show (1) or suppress (0) the test banner.
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
