### PR TITLE
Adding service mesh annotations

### DIFF
--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -177,7 +177,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	}
 	s.IperfService, err = CreateService(iperfSVC, client)
 	if err != nil {
-		return fmt.Errorf("😥 Unable to create iperf service")
+		return fmt.Errorf("😥 Unable to create iperf service: %v", err)
 	}
 
 	// Create netperf service
@@ -463,6 +463,9 @@ func CreateDeployment(dp DeploymentParams, client *kubernetes.Clientset) (*appsv
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: dp.Labels,
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
 				},
 				Spec: apiv1.PodSpec{
 					ServiceAccountName: sa,


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adding annotations to deployments to inject istio sidecar container when the namespace is included in the service mesh.
Just FYI, apart from these annotations, the `netperf` namespace needs to have an special label to be included in the servicemesh as well, so it's possible to opt-in/out k8s-netperf pods from ServiceMesh when needed

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
