### PR TITLE
Fix container and manifest targets in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CGO = 0
 RHEL_VERSION = ubi9
 CONTAINER ?= podman
 CONTAINER_BUILD ?= podman build --force-rm
-CONTAINER_NS ?= quay.io/cloud-bulldozer/netperf
+CONTAINER_NS ?= quay.io/cloud-bulldozer
 SOURCES := $(shell find . -type f -name "*.go")
 
 # k8s-netperf version
@@ -38,17 +38,17 @@ container-build: build
 	@echo "Building the container image"
 	$(CONTAINER_BUILD) -f containers/Containerfile \
 		--build-arg RHEL_VERSION=$(RHEL_VERSION) \
-		-t $(CONTAINER_NS)/$(BIN) ./containers
+		-t $(CONTAINER_NS)/$(BIN):latest ./containers
 
-gha-build: build
+gha-build:
 	@echo "Building the container image for GHA"
 	$(CONTAINER_BUILD) -f containers/Containerfile \
 		--build-arg RHEL_VERSION=$(RHEL_VERSION) --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
-		-t $(CONTAINER_NS) ./containers --manifest=$(CONTAINER_NS)-manifest:latest
+		./containers --manifest=$(CONTAINER_NS)/${BIN}:latest
 
-gha-push:
+gha-push: gha-build
 	@echo "Pushing Container Images & manifest"
-	$(CONTAINER) manifest push $(CONTAINER_NS)-manifest:latest $(CONTAINER_NS)
+	$(CONTAINER) manifest push $(CONTAINER_NS)/${BIN}:latest $(CONTAINER_NS)/${BIN}:latest
 
 clean:
 	rm -rf bin/$(ARCH)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Some targets are broken:
- CONTAINER_NS doesn't is concatenated with $(BIN)
- There's no need to use the flat -t when building a manifest with multiple platforms/archs
- Adding the tag :latest to the container image, it's automatically added, but is helps on readability

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
- gha-push location was incorrect
