### PR TITLE
Wait for namespace deletion

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const namespace = "netperf"
 const index = "k8s-netperf"
 const retry = 3
 
@@ -304,32 +303,7 @@ var rootCmd = &cobra.Command{
 }
 
 func cleanup(client *kubernetes.Clientset) {
-	log.Info("Cleaning resources created by k8s-netperf")
-	svcList, err := k8s.GetServices(client, namespace)
-	if err != nil {
-		log.Fatal(err)
-	}
-	for svc := range svcList.Items {
-		err = k8s.DestroyService(client, svcList.Items[svc])
-		if err != nil {
-			log.Error(err)
-		}
-	}
-	dpList, err := k8s.GetDeployments(client, namespace)
-	if err != nil {
-		log.Fatal(err)
-	}
-	for dp := range dpList.Items {
-		err = k8s.DestroyDeployment(client, dpList.Items[dp])
-		if err != nil {
-			log.Error(err)
-		}
-		_, err := k8s.WaitForDelete(client, dpList.Items[dp])
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-	err = k8s.DestroyNamespace(client)
+	err := k8s.DestroyNamespace(client)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -56,7 +56,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, 
 	id := uuid.New()
 	file := fmt.Sprintf("/tmp/iperf-%s", id.String())
 	pod := client.Items[0]
-	log.Debugf("🔥 Client (%s,%s) starting iperf3 against server : %s", pod.Name, pod.Status.PodIP, serverIP)
+	log.Debugf("🔥 Client (%s,%s) starting iperf3 against server: %s", pod.Name, pod.Status.PodIP, serverIP)
 	config.Show(nc, i.driverName)
 	tcp := true
 	if !strings.Contains(nc.Profile, "STREAM") {

--- a/pkg/drivers/netperf.go
+++ b/pkg/drivers/netperf.go
@@ -38,7 +38,7 @@ const omniOptions = "rt_latency,p99_latency,throughput,throughput_units,remote_r
 func (n *netperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1.PodList, serverIP string) (bytes.Buffer, error) {
 	var stdout, stderr bytes.Buffer
 	pod := client.Items[0]
-	log.Debugf("🔥 Client (%s,%s) starting netperf against server : %s", pod.Name, pod.Status.PodIP, serverIP)
+	log.Debugf("🔥 Client (%s,%s) starting netperf against server: %s", pod.Name, pod.Status.PodIP, serverIP)
 	config.Show(nc, n.driverName)
 	cmd := []string{superNetperf, strconv.Itoa(nc.Parallelism), strconv.Itoa(k8s.NetperfServerDataPort), "-H",
 		serverIP, "-l",

--- a/pkg/drivers/uperf.go
+++ b/pkg/drivers/uperf.go
@@ -142,7 +142,7 @@ func (u *uperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, c
 	var exec remotecommand.Executor
 
 	pod := client.Items[0]
-	log.Debugf("🔥 Client (%s,%s) starting uperf against server : %s", pod.Name, pod.Status.PodIP, serverIP)
+	log.Debugf("🔥 Client (%s,%s) starting uperf against server: %s", pod.Name, pod.Status.PodIP, serverIP)
 	config.Show(nc, u.driverName)
 
 	filePath, err := createUperfProfile(c, rc, nc, pod, serverIP)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

It's easier and faster to wait for the namespace deletion rather than resource by resource.

It also fixes a race condition that happens when you execute k8s-netperf twice without waiting for some time between executions, the netperf namespace is still in `Deleting` status and k8s-netperf crashes. e.g:

```shell
$ ./bin/amd64/k8s-netperf --config examples/netperf-full.yml  --debug --all                                                                                                                      
INFO[2024-04-30 11:19:37] Starting k8s-netperf (141@b939249af9389f95d195eedcb47dce131a209342)                                                                                                                                                 
INFO[2024-04-30 11:19:37] 📒 Reading examples/netperf-full.yml file.                                                                                                                                                                          
INFO[2024-04-30 11:19:37] 📒 Reading examples/netperf-full.yml file - using ConfigV2 Method.                                                                                                                                                  
INFO[2024-04-30 11:19:37] Cleaning resources created by k8s-netperf                                                                                                                                                                           
INFO[2024-04-30 11:19:40] ⏰ Waiting for client-across Deployment to deleted...                                                                                                                                                               
INFO[2024-04-30 11:19:42] ⏰ Waiting for client-host Deployment to deleted...                                          
INFO[2024-04-30 11:19:44] ⏰ Waiting for server Deployment to deleted...                                                                                                                                                                      
INFO[2024-04-30 11:19:46] ⏰ Waiting for server-host Deployment to deleted...                                                                                                                                                                 
INFO[2024-04-30 11:19:49] 🔬 prometheus discovered at openshift-monitoring                                                                                                                                                                    
INFO[2024-04-30 11:19:51] ♻️  Namespace already exists, reusing it                                                                                                                                                                             
INFO[2024-04-30 11:19:51] ♻️  Service account already exists, reusing it                                                                                                                                                                      
INFO[2024-04-30 11:19:51] ♻️  Role binding already exists, reusing it                                                                                                                                                                          
WARN[2024-04-30 11:19:52] ⚠️   Single node per zone and/or no zone labels                                                                                                                                                                     
DEBU[2024-04-30 11:19:52] Number of nodes with role worker: 3                                                                                                                                                                                 
DEBU[2024-04-30 11:19:52] Looking for service iperf-service in namespace netperf                                                                                                                                                              
INFO[2024-04-30 11:19:52] 🚀 Creating service for iperf-service in namespace netperf                                                                                                                                                          
FATA[2024-04-30 11:19:52] 😥 Unable to create iperf service: services "iperf-service" is forbidden: unable to create new content in namespace netperf because it is being terminated
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
