### PR TITLE
Fix uperf RR reporting

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -364,7 +364,7 @@ func executeWorkload(nc config.Config, s config.PerfScenarios, hostNet bool, dri
 		if err != nil {
 			log.Fatal(err)
 		}
-		nr, err = driver.ParseResults(&r)
+		nr, err = driver.ParseResults(&r, nc)
 		if err != nil {
 			log.Error(err)
 			try := 0
@@ -377,7 +377,7 @@ func executeWorkload(nc config.Config, s config.PerfScenarios, hostNet bool, dri
 					log.Error(err)
 					continue
 				}
-				nr, err = driver.ParseResults(&r)
+				nr, err = driver.ParseResults(&r, nc)
 				if err != nil {
 					log.Error(err)
 					try++

--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -13,7 +13,7 @@ import (
 type Driver interface {
 	IsTestSupported(string) bool
 	Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1.PodList, serverIP string) (bytes.Buffer, error)
-	ParseResults(stdout *bytes.Buffer) (sample.Sample, error)
+	ParseResults(stdout *bytes.Buffer, nc config.Config) (sample.Sample, error)
 }
 
 type netperf struct {

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -151,7 +151,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, 
 
 // ParseResults accepts the stdout from the execution of the benchmark.
 // It will return a Sample struct or error
-func (i *iperf3) ParseResults(stdout *bytes.Buffer) (sample.Sample, error) {
+func (i *iperf3) ParseResults(stdout *bytes.Buffer, _ config.Config) (sample.Sample, error) {
 	sample := sample.Sample{}
 	sample.Driver = i.driverName
 	result := IperfResult{}

--- a/pkg/drivers/netperf.go
+++ b/pkg/drivers/netperf.go
@@ -82,7 +82,7 @@ func (n *netperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config,
 
 // ParseResults accepts the stdout from the execution of the benchmark. It also needs
 // It will return a Sample struct or error
-func (n *netperf) ParseResults(stdout *bytes.Buffer) (sample.Sample, error) {
+func (n *netperf) ParseResults(stdout *bytes.Buffer, _ config.Config) (sample.Sample, error) {
 	sample := sample.Sample{}
 	sample.Driver = n.driverName
 	send := 0.0

--- a/pkg/drivers/uperf.go
+++ b/pkg/drivers/uperf.go
@@ -190,7 +190,7 @@ func (u *uperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, c
 
 // ParseResults accepts the stdout from the execution of the benchmark.
 // It will return a Sample struct or error
-func (u *uperf) ParseResults(stdout *bytes.Buffer) (sample.Sample, error) {
+func (u *uperf) ParseResults(stdout *bytes.Buffer, nc config.Config) (sample.Sample, error) {
 	sample := sample.Sample{}
 	sample.Driver = u.driverName
 	sample.Metric = "Mb/s"
@@ -218,10 +218,13 @@ func (u *uperf) ParseResults(stdout *bytes.Buffer) (sample.Sample, error) {
 
 	}
 	averageByte, _ := stats.Mean(byteSummary)
-	averageOps, _ := stats.Mean(opSummary)
-	sample.Throughput = float64(averageByte*8) / 1000000
+	if strings.Contains(nc.Profile, "STREAM") {
+		sample.Throughput = float64(averageByte*8) / 1000000
+	} else {
+		sample.Throughput, _ = stats.Mean(opSummary)
+	}
 	sample.Latency99ptile, _ = stats.Percentile(latSummary, 99)
-	log.Debugf("Storing uperf sample throughput: %f Mbps, P99 Latency %f, Average ops: %f ", sample.Throughput, sample.Latency99ptile, averageOps)
+	log.Debugf("Storing uperf sample Average bytes: %f , P99 Latency %f, Throughput: %f ", averageByte, sample.Latency99ptile, sample.Throughput)
 
 	return sample, nil
 


### PR DESCRIPTION
Uperf was reporting Mbps for RR throughput instead of op/s. Fixed that in this patch.

fixes #144

