### PR TITLE
Report avg from processes latency

### DIFF
--- a/containers/super-netperf
+++ b/containers/super-netperf
@@ -34,7 +34,9 @@ process_netperf() {
     retrans=0
     u=""
     top=""
+    counter=0
     for file in `ls /tmp/result-*`; do
+      counter=$((counter + 1))
       top=$(head -n 1 $file)
       t=$(cat $file | grep "THROUGHPUT=" | awk -F= '{print $2}')
       s=$(cat $file | grep "LOCAL_SEND_CALLS=" | awk -F= '{print $2}')
@@ -47,7 +49,7 @@ process_netperf() {
         rtl=$(echo $rtl+$rrtl | bc)
       fi
       rl=$(cat $file | grep "P99_LATENCY=" | awk -F= '{print $2}')
-      l=$(echo $l+rl | bc)
+      l=$(echo $l+$rl | bc)
       tp=$(echo $tp+$t | bc)
       send=$(echo $send+$s | bc)
       recv=$(echo $recv+$r | bc)
@@ -56,9 +58,13 @@ process_netperf() {
       filename=$(basename $file)
       mv $file /tmp/old-$filename
     done
+    # Calculate average of average latency from all netperf processes.
+    rtl=$(echo $rtl/$counter | bc)
+    # Calculate average P99 latency from all netperf processes.
+    l=$(echo $l/$counter | bc)
     echo "$top"
     echo "RT_LATENCY=$rtl"
-    echo "P99_LATENCY=$rl"
+    echo "P99_LATENCY=$l"
     echo "THROUGHPUT=$tp"
     echo "LOCAL_TRANSPORT_RETRANS=$retrans"
     echo "REMOTE_RECV_CALLS=$recv"


### PR DESCRIPTION
super-netperf script runs multiple netperf processes. Each process provides average latency and P99 latency as output. For reporting, this script calculates average from all of the processes latency. Calculating P99 latency from all the P99 latencies is difficult in bash script. Instead we are calculating average from all the P99 latencies similar to what ingress-perf does.

So the report will have
1. Average of average latencies
2. Average of P99 latencies

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
