### PR TITLE
Adding support of UDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,19 @@ Flags:
       --clean                 Clean-up resources created by k8s-netperf (default true)
       --json                  Instead of human-readable output, return JSON to stdout
       --local                 Run network performance tests with Server-Pods/Client-Pods on the same Node
+      --vm                    Launch Virtual Machines instead of pods for client/servers
       --across                Place the client and server across availability zones
       --all                   Run all tests scenarios - hostNet and podNetwork (if possible)
       --debug                 Enable debug log
+      --udn                   Create and use a UDN called 'udn-l2-primary' as a primary network.
       --prom string           Prometheus URL
       --uuid string           User provided UUID
       --search string         OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port
+      --index string          OpenSearch Index to save the results to, defaults to k8s-netperf
       --metrics               Show all system metrics retrieved from prom
       --tcp-tolerance float   Allowed %diff from hostNetwork to podNetwork, anything above tolerance will result in k8s-netperf exiting 1. (default 10)
       --version               k8s-netperf version
+      --csv                   Archive results, cluster and benchmark metrics in CSV files (default true)
   -h, --help                  help for k8s-netperf
 
 

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -39,6 +39,7 @@ var (
 	netperf     bool
 	iperf3      bool
 	uperf       bool
+	udn         bool
 	acrossAZ    bool
 	full        bool
 	vm          bool
@@ -151,19 +152,36 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if vm {
-			s.VM = true
+		if udn {
+			s.Udn = true
 			// Create a dynamic client
 			dynClient, err := dynamic.NewForConfig(rconfig)
 			if err != nil {
 				log.Error(err)
+			}
+			s.DClient = dynClient
+			err = k8s.DeployL2Udn(dynClient)
+			if err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
+		}
+
+		if vm {
+			s.VM = true
+			// Create a dynamic client
+			if s.DClient == nil {
+				dynClient, err := dynamic.NewForConfig(rconfig)
+				if err != nil {
+					log.Error(err)
+				}
+				s.DClient = dynClient
 			}
 			kclient, err := kubevirtv1.NewForConfig(rconfig)
 			if err != nil {
 				log.Error(err)
 			}
 			s.KClient = kclient
-			s.DClient = dynClient
 		}
 
 		// Build the SUT (Deployments)
@@ -374,6 +392,7 @@ func executeWorkload(nc config.Config,
 	hostNet bool,
 	driverName string, virt bool) result.Data {
 	serverIP := ""
+	var err error
 	Client := s.Client
 	var driver drivers.Driver
 	if nc.Service {
@@ -383,6 +402,11 @@ func executeWorkload(nc config.Config,
 			serverIP = s.UperfService.Spec.ClusterIP
 		} else {
 			serverIP = s.NetperfService.Spec.ClusterIP
+		}
+	} else if s.Udn {
+		serverIP, err = k8s.ExtractUdnIp(s)
+		if err != nil {
+			log.Fatal(err)
 		}
 	} else {
 		if hostNet {
@@ -481,6 +505,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&acrossAZ, "across", false, "Place the client and server across availability zones")
 	rootCmd.Flags().BoolVar(&full, "all", false, "Run all tests scenarios - hostNet and podNetwork (if possible)")
 	rootCmd.Flags().BoolVar(&debug, "debug", false, "Enable debug log")
+	rootCmd.Flags().BoolVar(&udn, "udn", false, "Create and use a UDN called 'udn-l2-primary' as primary network.")
 	rootCmd.Flags().StringVar(&promURL, "prom", "", "Prometheus URL")
 	rootCmd.Flags().StringVar(&id, "uuid", "", "User provided UUID")
 	rootCmd.Flags().StringVar(&searchURL, "search", "", "OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type PerfScenarios struct {
 	Configs        []Config
 	VM             bool
 	VMHost         string
+	Udn            bool
 	ServerNodeInfo metrics.NodeInfo
 	ClientNodeInfo metrics.NodeInfo
 	Client         apiv1.PodList


### PR DESCRIPTION
Using --udn option create a UserDefinedNetwork object on the netperf ns

## Type of change

- [X] New feature

## Description

This new option deploys a UDN network in the netperf Namespace. All the pods are using the UDN interface to contact each other.
It does not support Service and IPv6 (even if the implementation of v6 looks straightforward).

It uses the CRD `userdefinednetworks` and not a NAD to create the UDN interfaces on the pods.

## Related Tickets & Documents

- Related Issue # PERFSCALE-3552
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Testing
- OCP cluster baremetal 4.17.2 - TechPreview enabled.
- Run the default netperf.yml config, without the Service Test.
