### PR TITLE
Label hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ $ make container-build
 
 ## Label nodes
 k8s-netperf will make the best decision it can to schedule the client and server in your cluster. However,
-you can provide hints to ensure the client and server will always land on specific nodes.
+you can provide hints to ensure the client and server lands on specific nodes.
 
 To do this, apply a label to the nodes you want the client and server running
 
 ```shell
-$ oc label nodes node-name netperf=true
+$ oc label nodes node-name netperf=client
+$ oc label nodes node-name netperf=server
 ```
 
 ## Running with Pods

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ $ cd k8s-netperf
 $ make container-build
 ```
 
+## Label nodes
+k8s-netperf will make the best decision it can to schedule the client and server in your cluster. However,
+you can provide hints to ensure the client and server will always land on specific nodes.
+
+To do this, apply a label to the nodes you want the client and server running
+
+```shell
+$ oc label nodes node-name netperf=true
+```
+
 ## Running with Pods
 Ensure your `kubeconfig` is properly set to the cluster you would like to run `k8s-netperf` against.
 

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -342,6 +342,21 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				RequiredDuringSchedulingIgnoredDuringExecution: workerNodeSelectorExpression,
 			}
 		}
+	} else {
+		affinity := corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 100,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+						},
+					},
+				},
+			},
+		}
+		cdpAcross.NodeAffinity = affinity
+		cdpHostAcross.NodeAffinity = affinity
 	}
 
 	if ncount > 1 {
@@ -424,6 +439,21 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			affinity = corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: workerNodeSelectorExpression,
 			}
+		}
+		sdp.NodeAffinity = affinity
+		sdpHost.NodeAffinity = affinity
+	} else {
+		affinity := corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 100,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+						},
+					},
+				},
+			},
 		}
 		sdp.NodeAffinity = affinity
 		sdpHost.NodeAffinity = affinity
@@ -583,6 +613,7 @@ func zoneNodeSelectorExpression(zone string) []corev1.PreferredSchedulingTerm {
 			Preference: corev1.NodeSelectorTerm{
 				MatchExpressions: []corev1.NodeSelectorRequirement{
 					{Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{zone}},
+					{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
 				},
 			},
 		},

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -248,7 +248,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		}
 		if z != "" && numNodes > 1 {
 			cdp.NodeAffinity = corev1.NodeAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: zoneNodeSelectorExpression(z),
+				PreferredDuringSchedulingIgnoredDuringExecution: zoneNodeSelectorExpression(z, "client"),
 			}
 		}
 
@@ -334,7 +334,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	if z != "" {
 		if numNodes > 1 {
 			cdpAcross.NodeAffinity = corev1.NodeAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: zoneNodeSelectorExpression(z),
+				PreferredDuringSchedulingIgnoredDuringExecution: zoneNodeSelectorExpression(z, "client"),
 				RequiredDuringSchedulingIgnoredDuringExecution:  workerNodeSelectorExpression,
 			}
 		} else {
@@ -349,7 +349,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 					Weight: 100,
 					Preference: corev1.NodeSelectorTerm{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+							{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"client"}},
 						},
 					},
 				},
@@ -362,7 +362,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	if ncount > 1 {
 		if s.HostNetwork {
 			cdpHostAcross.NodeAffinity = corev1.NodeAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: zoneNodeSelectorExpression(z),
+				PreferredDuringSchedulingIgnoredDuringExecution: zoneNodeSelectorExpression(z, "client"),
 				RequiredDuringSchedulingIgnoredDuringExecution:  workerNodeSelectorExpression,
 			}
 			cdpHostAcross.PodAntiAffinity = corev1.PodAntiAffinity{
@@ -427,9 +427,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	if z != "" {
 		var affinity corev1.NodeAffinity
 		if numNodes > 1 {
-			nodeZone := zoneNodeSelectorExpression(z)
+			nodeZone := zoneNodeSelectorExpression(z, "server")
 			if s.AcrossAZ {
-				nodeZone = zoneNodeSelectorExpression(acrossZone)
+				nodeZone = zoneNodeSelectorExpression(acrossZone, "server")
 			}
 			affinity = corev1.NodeAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: nodeZone,
@@ -449,7 +449,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 					Weight: 100,
 					Preference: corev1.NodeSelectorTerm{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+							{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"server"}},
 						},
 					},
 				},
@@ -606,14 +606,14 @@ func launchClientVM(perf *config.PerfScenarios, name string, podAff *corev1.PodA
 	return nil
 }
 
-func zoneNodeSelectorExpression(zone string) []corev1.PreferredSchedulingTerm {
+func zoneNodeSelectorExpression(zone string, role string) []corev1.PreferredSchedulingTerm {
 	return []corev1.PreferredSchedulingTerm{
 		{
 			Weight: 100,
 			Preference: corev1.NodeSelectorTerm{
 				MatchExpressions: []corev1.NodeSelectorRequirement{
 					{Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{zone}},
-					{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+					{Key: "netperf", Operator: corev1.NodeSelectorOpIn, Values: []string{role}},
 				},
 			},
 		},


### PR DESCRIPTION

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
If the user wants to provide hints to help schedule the client and server on specific nodes, they can add `netperf=true` label to the nodes they want tested.

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
