### PR TITLE
support for external server

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Flags:
       --all                   Run all tests scenarios - hostNet and podNetwork (if possible)
       --debug                 Enable debug log
       --udn                   Create and use a UDN called 'udn-l2-primary' as a primary network.
+      --serverIP string       External Server IP Address for the OCP client pod to communicate with.
       --prom string           Prometheus URL
       --uuid string           User provided UUID
       --search string         OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port
@@ -103,6 +104,7 @@ Flags:
 - `--across` will force the client to be across availability zones from the server
 - `--json` will reduce all output to just the JSON result, allowing users to feed the result to `jq` or other tools. Only output to the screen will be the result JSON or errors.
 - `--clean=true` will delete all the resources the project creates (deployments and services)
+- `--serverIP` accepts a string (IP Address). Example  44.243.95.221. k8s-netperf assumes this as server address and the client sends requests to this IP address.
 - `--prom` accepts a string (URL). Example  http://localhost:9090
   - When using `--prom` with a non-openshift cluster, it will be necessary to pass the prometheus URL.
 - `--metrics` will enable displaying prometheus captured metrics to stdout. By default they will be written to a csv file.
@@ -110,6 +112,15 @@ Flags:
 - `--uperf` will enable the uperf load driver for any stream test (TCP_STREAM, UDP_STREAM). uperf doesn't have CRR test-type.
 
 > *Note: With OpenShift, we attempt to discover the OpenShift route. If that route is not reachable, it might be required to `port-forward` the service and pass that via the `--prom` option.*
+
+## Using External Server
+This enables k8s-netperf to use the IP address provided via the `--serverIP` option as server address and the client sends requests to this IP address. This allows dataplane testing between ocp internal client pod and external server.
+
+> *Note: User has to create a server with the provided IP address and run the intented k8s-netperf driver (i.e uperf, iperf or netperf). User has to enable respective ports on this server to allow the traffic from the client*
+
+Once the external server is ready to accept the traffic, users can orhestrate k8s-netperf by running
+
+`k8s-netperf --serverIP=44.243.95.221`
 
 ## Running with VMs
 Running k8s-netperf against Virtual Machines (OpenShift CNV) requires
@@ -197,57 +208,57 @@ In order to have `k8s-netperf` determine pass/fail the user must pass the `--all
 
 ```shell
 $ ./k8s-netperf --tcp-tolerance 1
-+-------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+--------------------+
-|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
-+-------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+--------------------+
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 2661.006667 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 2483.078229 (Mb/s) |
-| 📊 Stream Results | uperf   | TCP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 2581.705097 (Mb/s) |
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 2702.230000 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 2523.434069 (Mb/s) |
-| 📊 Stream Results | uperf   | TCP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 2567.665412 (Mb/s) |
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | 8192         | 0     | false     | 10       | 3       | 2697.276667 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | 8192         | 0     | false     | 10       | 3       | 2542.793728 (Mb/s) |
-| 📊 Stream Results | uperf   | TCP_STREAM | 1           | true         | false   | 8192         | 0     | false     | 10       | 3       | 2571.881579 (Mb/s) |
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | 8192         | 0     | false     | 10       | 3       | 2707.076667 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | 8192         | 0     | false     | 10       | 3       | 2604.067072 (Mb/s) |
-| 📊 Stream Results | uperf   | TCP_STREAM | 1           | false        | false   | 8192         | 0     | false     | 10       | 3       | 2687.276667 (Mb/s) |
-| 📊 Stream Results | netperf | UDP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 1143.926667 (Mb/s) |
-| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 1202.428288 (Mb/s) |
-| 📊 Stream Results | uperf   | UDP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 1242.059988 (Mb/s) |
-| 📊 Stream Results | netperf | UDP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 1145.066667 (Mb/s) |
-| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 1239.580672 (Mb/s) |
-| 📊 Stream Results | uperf   | UDP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 1261.840000 (Mb/s) |
++-------------------+---------+------------+-------------+--------------+---------+-----------------+-------+-----------+----------+---------+--------------------+
+|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
++-------------------+---------+------------+-------------+--------------+---------+-----------------+-------+-----------+----------+---------+--------------------+
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 2661.006667 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 2483.078229 (Mb/s) |
+| 📊 Stream Results | uperf   | TCP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 2581.705097 (Mb/s) |
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 2702.230000 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 2523.434069 (Mb/s) |
+| 📊 Stream Results | uperf   | TCP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 2567.665412 (Mb/s) |
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | false           | 8192         | 0     | false     | 10       | 3       | 2697.276667 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | false           | 8192         | 0     | false     | 10       | 3       | 2542.793728 (Mb/s) |
+| 📊 Stream Results | uperf   | TCP_STREAM | 1           | true         | false   | false           | 8192         | 0     | false     | 10       | 3       | 2571.881579 (Mb/s) |
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | false           | 8192         | 0     | false     | 10       | 3       | 2707.076667 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | false           | 8192         | 0     | false     | 10       | 3       | 2604.067072 (Mb/s) |
+| 📊 Stream Results | uperf   | TCP_STREAM | 1           | false        | false   | false           | 8192         | 0     | false     | 10       | 3       | 2687.276667 (Mb/s) |
+| 📊 Stream Results | netperf | UDP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 1143.926667 (Mb/s) |
+| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 1202.428288 (Mb/s) |
+| 📊 Stream Results | uperf   | UDP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 1242.059988 (Mb/s) |
+| 📊 Stream Results | netperf | UDP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 1145.066667 (Mb/s) |
+| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 1239.580672 (Mb/s) |
+| 📊 Stream Results | uperf   | UDP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 1261.840000 (Mb/s) |
 +-------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+--------------------+
 +---------------+---------+----------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+---------------------+
-|  RESULT TYPE  | DRIVER  | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |      AVG VALUE      |
+|  RESULT TYPE  | DRIVER  | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |      AVG VALUE      |
 +---------------+---------+----------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+---------------------+
-| 📊 Rr Results | netperf | TCP_CRR  | 1           | true         | true    | 1024         | 0     | false     | 10       | 3       | 2370.196667 (OP/s)  |
-| 📊 Rr Results | netperf | TCP_CRR  | 1           | false        | true    | 1024         | 0     | false     | 10       | 3       | 3046.126667 (OP/s)  |
-| 📊 Rr Results | netperf | TCP_RR   | 1           | true         | false   | 1024         | 2     | false     | 10       | 3       | 16849.056667 (OP/s) |
-| 📊 Rr Results | netperf | TCP_RR   | 1           | false        | false   | 1024         | 2     | false     | 10       | 3       | 17101.856667 (OP/s) |
-| 📊 Rr Results | netperf | TCP_CRR  | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 3166.136667 (OP/s)  |
-| 📊 Rr Results | netperf | TCP_CRR  | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 1787.530000 (OP/s)  |
+| 📊 Rr Results | netperf | TCP_CRR  | 1           | true         | true    | false           | 1024         | 0     | false     | 10       | 3       | 2370.196667 (OP/s)  |
+| 📊 Rr Results | netperf | TCP_CRR  | 1           | false        | true    | false           | 1024         | 0     | false     | 10       | 3       | 3046.126667 (OP/s)  |
+| 📊 Rr Results | netperf | TCP_RR   | 1           | true         | false   | false           | 1024         | 2     | false     | 10       | 3       | 16849.056667 (OP/s) |
+| 📊 Rr Results | netperf | TCP_RR   | 1           | false        | false   | false           | 1024         | 2     | false     | 10       | 3       | 17101.856667 (OP/s) |
+| 📊 Rr Results | netperf | TCP_CRR  | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 3166.136667 (OP/s)  |
+| 📊 Rr Results | netperf | TCP_CRR  | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 1787.530000 (OP/s)  |
 +---------------+---------+----------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+---------------------+
 +---------------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+-----------------------------+
-|        RESULT TYPE        | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |   99%TILE VALUE   |
+|        RESULT TYPE        | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |   99%TILE VALUE   |
 +---------------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-------------------+
-| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 71.333333 (usec)  |
-| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 2.333333 (usec)   |
-| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | true         | false   | 8192         | 0     | false     | 10       | 3       | 276.000000 (usec) |
-| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | false        | false   | 8192         | 0     | false     | 10       | 3       | 124.333333 (usec) |
-| 📊 Stream Latency Results | netperf | UDP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 14.666667 (usec)  |
-| 📊 Stream Latency Results | netperf | UDP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 14.666667 (usec)  |
+| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 71.333333 (usec)  |
+| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 2.333333 (usec)   |
+| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | true         | false   | false           | 8192         | 0     | false     | 10       | 3       | 276.000000 (usec) |
+| 📊 Stream Latency Results | netperf | TCP_STREAM | 1           | false        | false   | false           | 8192         | 0     | false     | 10       | 3       | 124.333333 (usec) |
+| 📊 Stream Latency Results | netperf | UDP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 14.666667 (usec)  |
+| 📊 Stream Latency Results | netperf | UDP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 14.666667 (usec)  |
 +---------------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-------------------+
 +-----------------------+---------+----------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-------------------+
-|      RESULT TYPE      | DRIVER  | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |   99%TILE VALUE   |
+|      RESULT TYPE      | DRIVER  | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |   99%TILE VALUE   |
 +-----------------------+---------+----------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-------------------+
-| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | true         | true    | 1024         | 0     | false     | 10       | 3       | 817.333333 (usec) |
-| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | false        | true    | 1024         | 0     | false     | 10       | 3       | 647.666667 (usec) |
-| 📊 Rr Latency Results | netperf | TCP_RR   | 1           | true         | false   | 1024         | 2     | false     | 10       | 3       | 125.333333 (usec) |
-| 📊 Rr Latency Results | netperf | TCP_RR   | 1           | false        | false   | 1024         | 2     | false     | 10       | 3       | 119.666667 (usec) |
-| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 621.000000 (usec) |
-| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 539.666667 (usec) |
+| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | true         | true    | false           | 1024         | 0     | false     | 10       | 3       | 817.333333 (usec) |
+| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | false        | true    | false           | 1024         | 0     | false     | 10       | 3       | 647.666667 (usec) |
+| 📊 Rr Latency Results | netperf | TCP_RR   | 1           | true         | false   | false           | 1024         | 2     | false     | 10       | 3       | 125.333333 (usec) |
+| 📊 Rr Latency Results | netperf | TCP_RR   | 1           | false        | false   | false           | 1024         | 2     | false     | 10       | 3       | 119.666667 (usec) |
+| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 621.000000 (usec) |
+| 📊 Rr Latency Results | netperf | TCP_CRR  | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 539.666667 (usec) |
 +-----------------------+---------+----------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-------------------+
 😥 TCP Stream percent difference when comparing hostNetwork to podNetwork is greater than 1.0 percent (2.7 percent)
 $ echo $?
@@ -275,20 +286,20 @@ Document format can be seen in `pkg/archive/archive.go`
 Same node refers to how the pods were deployed. If the cluster has > 2 nodes with nodes which have `worker=` there will be a cross-node throughput test.
 ```shell
 +-------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+--------------------+
-|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
+|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
 +-------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+--------------------+
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 2661.006667 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 2483.078229 (Mb/s) |
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 2702.230000 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 2523.434069 (Mb/s) |
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | 8192         | 0     | false     | 10       | 3       | 2697.276667 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | 8192         | 0     | false     | 10       | 3       | 2542.793728 (Mb/s) |
-| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | 8192         | 0     | false     | 10       | 3       | 2707.076667 (Mb/s) |
-| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | 8192         | 0     | false     | 10       | 3       | 2604.067072 (Mb/s) |
-| 📊 Stream Results | netperf | UDP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 1143.926667 (Mb/s) |
-| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | true         | false   | 1024         | 0     | false     | 10       | 3       | 1202.428288 (Mb/s) |
-| 📊 Stream Results | netperf | UDP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 1145.066667 (Mb/s) |
-| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 1239.580672 (Mb/s) |
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 2661.006667 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 2483.078229 (Mb/s) |
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 2702.230000 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 2523.434069 (Mb/s) |
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | false           | 8192         | 0     | false     | 10       | 3       | 2697.276667 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | false           | 8192         | 0     | false     | 10       | 3       | 2542.793728 (Mb/s) |
+| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | false           | 8192         | 0     | false     | 10       | 3       | 2707.076667 (Mb/s) |
+| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | false           | 8192         | 0     | false     | 10       | 3       | 2604.067072 (Mb/s) |
+| 📊 Stream Results | netperf | UDP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 1143.926667 (Mb/s) |
+| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | true         | false   | false           | 1024         | 0     | false     | 10       | 3       | 1202.428288 (Mb/s) |
+| 📊 Stream Results | netperf | UDP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 1145.066667 (Mb/s) |
+| 📊 Stream Results | iperf3  | UDP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 1239.580672 (Mb/s) |
 +-------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+--------------------+
 ```
 
@@ -296,11 +307,11 @@ Same node refers to how the pods were deployed. If the cluster has > 2 nodes wit
 k8s-netperf will report TCP Retransmissions and UDP Loss for both workload drivers (netperf and iperf).
 ```shell
 +---------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-----------+
-|        TYPE         | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES | AVG VALUE |
+|        TYPE         | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES | AVG VALUE |
 +---------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-----------+
-| TCP Retransmissions | netperf | TCP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 54.666667 |
-| TCP Retransmissions | netperf | TCP_STREAM | 1           | false        | false   | 8192         | 0     | false     | 10       | 3       | 15.000000 |
-| UDP Loss Percent    | netperf | UDP_STREAM | 1           | false        | false   | 1024         | 0     | false     | 10       | 3       | 0.067031  |
+| TCP Retransmissions | netperf | TCP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 54.666667 |
+| TCP Retransmissions | netperf | TCP_STREAM | 1           | false        | false   | false           | 8192         | 0     | false     | 10       | 3       | 15.000000 |
+| UDP Loss Percent    | netperf | UDP_STREAM | 1           | false        | false   | false           | 1024         | 0     | false     | 10       | 3       | 0.067031  |
 +---------------------+---------+------------+-------------+--------------+---------+--------------+-------+-----------+----------+---------+-----------+
 ```
 
@@ -309,11 +320,11 @@ k8s-netperf will report TCP Retransmissions and UDP Loss for both workload drive
 
 Example output
 ```csv
-Driver,Profile,Same node,Host Network,Service,Duration,Parallelism,# of Samples,Message Size,Confidence metric - low,Confidence metric - high,Avg Throughput,Throughput Metric,99%tile Observed Latency,Latency Metric
-netperf,TCP_STREAM,false,false,false,10,1,3,1024,861.9391413991156,885.2741919342178,873.606667,Mb/s,3.3333333333333335,usec
-netperf,TCP_STREAM,false,false,false,10,1,3,8192,178.12442996547009,1310.3422367011967,744.233333,Mb/s,2394.6666666666665,usec
-netperf,UDP_STREAM,false,false,false,10,1,3,1024,584.3478157889886,993.4588508776783,788.903333,Mb/s,23,usec
-netperf,TCP_CRR,false,false,false,10,1,3,1024,1889.3183973002176,2558.074936033115,2223.696667,OP/s,4682.666666666667,usec
-netperf,TCP_CRR,false,false,true,10,1,3,1024,1169.206855676418,2954.3464776569153,2061.776667,OP/s,4679.333333333333,usec
-netperf,TCP_RR,false,false,false,10,1,3,1024,6582.5359452538705,12085.437388079461,9333.986667,OP/s,451.3333333333333,usec
+Driver,Profile,Same node,Host Network,Service,External Server,Duration,Parallelism,# of Samples,Message Size,Confidence metric - low,Confidence metric - high,Avg Throughput,Throughput Metric,99%tile Observed Latency,Latency Metric
+netperf,TCP_STREAM,false,false,false,false,10,1,3,1024,861.9391413991156,885.2741919342178,873.606667,Mb/s,3.3333333333333335,usec
+netperf,TCP_STREAM,false,false,false,false,10,1,3,8192,178.12442996547009,1310.3422367011967,744.233333,Mb/s,2394.6666666666665,usec
+netperf,UDP_STREAM,false,false,false,false,10,1,3,1024,584.3478157889886,993.4588508776783,788.903333,Mb/s,23,usec
+netperf,TCP_CRR,false,false,false,false,10,1,3,1024,1889.3183973002176,2558.074936033115,2223.696667,OP/s,4682.666666666667,usec
+netperf,TCP_CRR,false,false,true,false,10,1,3,1024,1169.206855676418,2954.3464776569153,2061.776667,OP/s,4679.333333333333,usec
+netperf,TCP_RR,false,false,false,false,10,1,3,1024,6582.5359452538705,12085.437388079461,9333.986667,OP/s,451.3333333333333,usec
 ```

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -128,6 +128,9 @@ var rootCmd = &cobra.Command{
 			Configs:     cfg,
 			ClientSet:   client,
 		}
+		if serverIPAddr != "" {
+			s.ExternalServer = true
+		}
 		// Get node count
 		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker="})
 		if err != nil {
@@ -480,7 +483,7 @@ func executeWorkload(nc config.Config,
 			serverIP = s.Server.Items[0].Status.PodIP
 		}
 	}
-	if !s.NodeLocal {
+	if !s.NodeLocal && !s.ExternalServer {
 		Client = s.ClientAcross
 	}
 	if hostNet {

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -58,6 +58,7 @@ var (
 	version       bool
 	csvArchive    bool
 	searchIndex   string
+	serverIPAddr  string
 )
 
 var rootCmd = &cobra.Command{
@@ -452,7 +453,11 @@ func executeWorkload(nc config.Config,
 	var err error
 	Client := s.Client
 	var driver drivers.Driver
-	if nc.Service {
+	npr := result.Data{}
+	if serverIPAddr != "" {
+		serverIP = serverIPAddr
+		npr.ExternalServer = true
+	} else if nc.Service {
 		if driverName == "iperf3" {
 			serverIP = s.IperfService.Spec.ClusterIP
 		} else if driverName == "uperf" {
@@ -481,7 +486,6 @@ func executeWorkload(nc config.Config,
 	if hostNet {
 		Client = s.ClientHost
 	}
-	npr := result.Data{}
 	npr.Config = nc
 	npr.Metric = nc.Metric
 	npr.Service = nc.Service
@@ -493,7 +497,7 @@ func executeWorkload(nc config.Config,
 		npr.AcrossAZ = nc.AcrossAZ
 	}
 	npr.StartTime = time.Now()
-	log.Debugf("Executing workloads. hostNetwork is %t, service is %t", hostNet, nc.Service)
+	log.Debugf("Executing workloads. hostNetwork is %t, service is %t, externalServer is %t", hostNet, nc.Service, npr.ExternalServer)
 	for i := 0; i < nc.Samples; i++ {
 		nr := sample.Sample{}
 		if driverName == "iperf3" {
@@ -577,6 +581,7 @@ func main() {
 	rootCmd.Flags().Float64Var(&tcpt, "tcp-tolerance", 10, "Allowed %diff from hostNetwork to podNetwork, anything above tolerance will result in k8s-netperf exiting 1.")
 	rootCmd.Flags().BoolVar(&version, "version", false, "k8s-netperf version")
 	rootCmd.Flags().BoolVar(&csvArchive, "csv", true, "Archive results, cluster and benchmark metrics in CSV files")
+	rootCmd.Flags().StringVar(&serverIPAddr, "serverIP", "", "External Server IP Address")
 	rootCmd.Flags().SortFlags = false
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -55,6 +55,7 @@ type Doc struct {
 	ServerVSwitchMem  float64          `json:"serverVswitchMem"`
 	ClientVSwitchCpu  float64          `json:"clientVswtichCpu"`
 	ClientVSwiitchMem float64          `json:"clientVswitchMem"`
+	ExternalServer    bool             `json:"externalServer"`
 }
 
 // Connect returns a client connected to the desired cluster.
@@ -107,6 +108,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 			Virt:              sr.Virt,
 			Samples:           r.Samples,
 			Service:           r.Service,
+			ExternalServer:    r.ExternalServer,
 			Messagesize:       r.MessageSize,
 			Burst:             r.Burst,
 			TputMetric:        r.Metric,
@@ -168,6 +170,7 @@ func commonCsvHeaderFields() []string {
 		"Same node",
 		"Host Network",
 		"Service",
+		"External Server",
 		"Duration",
 		"Parallelism",
 		"# of Samples",
@@ -190,6 +193,7 @@ func commonCsvDataFields(row result.Data) []string {
 		fmt.Sprint(row.SameNode),
 		fmt.Sprint(row.HostNetwork),
 		fmt.Sprint(row.Service),
+		fmt.Sprint(row.ExternalServer),
 		strconv.Itoa(row.Duration),
 		strconv.Itoa(row.Parallelism),
 		strconv.Itoa(row.Samples),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type PerfScenarios struct {
 	NodeLocal           bool
 	AcrossAZ            bool
 	HostNetwork         bool
+	ExternalServer      bool
 	Configs             []Config
 	VM                  bool
 	VMImage             string

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -204,6 +204,48 @@ func DeployNADBridge(dyn *dynamic.DynamicClient, bridgeName string) error {
 // BuildSUT Build the k8s env to run network performance tests
 func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	var netperfDataPorts []int32
+	var err error
+
+	// Schedule pods to nodes with role worker=, but not nodes with infra= and workload=
+	workerNodeSelectorExpression := &corev1.NodeSelector{
+		NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{Key: "node-role.kubernetes.io/worker", Operator: corev1.NodeSelectorOpIn, Values: []string{""}},
+					{Key: "node-role.kubernetes.io/infra", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
+					{Key: "node-role.kubernetes.io/workload", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
+				},
+			},
+		},
+	}
+
+	if s.ExternalServer {
+		//  Create Netperf client on any worker node. No service or server pod required in this scenario.
+		cdp := DeploymentParams{
+			Name:      "client",
+			Namespace: "netperf",
+			Replicas:  1,
+			Image:     k8sNetperfImage,
+			Labels:    map[string]string{"role": clientRole},
+			Commands:  [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
+			Port:      NetperfServerCtlPort,
+		}
+
+		cdp.NodeAffinity = corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: workerNodeSelectorExpression,
+		}
+
+		s.Client, err = deployDeployment(client, cdp)
+		if err != nil {
+			return err
+		}
+
+		s.ClientNodeInfo, err = GetPodNodeInfo(client, labels.Set(cdp.Labels).String())
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	// Check if nodes have the zone label to keep the netperf test
 	// in the same AZ/Zone versus across AZ/Zone
 	z, zones, err := GetZone(client)
@@ -239,19 +281,6 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	log.Debugf("Number of nodes with role worker: %d", ncount)
 	if (s.HostNetwork || !s.NodeLocal) && ncount < 2 {
 		return fmt.Errorf(" not enough nodes with label worker= to execute test (current number of nodes: %d).", ncount)
-	}
-
-	// Schedule pods to nodes with role worker=, but not nodes with infra= and workload=
-	workerNodeSelectorExpression := &corev1.NodeSelector{
-		NodeSelectorTerms: []corev1.NodeSelectorTerm{
-			{
-				MatchExpressions: []corev1.NodeSelectorRequirement{
-					{Key: "node-role.kubernetes.io/worker", Operator: corev1.NodeSelectorOpIn, Values: []string{""}},
-					{Key: "node-role.kubernetes.io/infra", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
-					{Key: "node-role.kubernetes.io/workload", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
-				},
-			},
-		},
 	}
 
 	clientRoleAffinity := []corev1.PodAffinityTerm{

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -46,6 +46,7 @@ type Data struct {
 	ClientPodMem      metrics.PodValues
 	ServerPodCPU      metrics.PodValues
 	ServerPodMem      metrics.PodValues
+	ExternalServer    bool
 }
 
 // ScenarioResults each scenario could have multiple results
@@ -191,13 +192,13 @@ func calDiff(a float64, b float64) float64 {
 
 // ShowPodCPU accepts ScenarioResults and presents to the user via stdout the PodCPU info
 func ShowPodCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -205,13 +206,13 @@ func ShowPodCPU(s ScenarioResults) {
 
 // ShowPodMem accepts ScenarioResults and presents to the user via stdout the Podmem info
 func ShowPodMem(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -219,7 +220,7 @@ func ShowPodMem(s ScenarioResults) {
 
 // ShowNodeCPU accepts ScenarioResults and presents to the user via stdout the NodeCPU info
 func ShowNodeCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
 	for _, r := range s.Results {
 		// Skip RR/CRR iperf3 Results
 		if strings.Contains(r.Profile, "RR") {
@@ -230,11 +231,11 @@ func ShowNodeCPU(s ScenarioResults) {
 		ccpu := r.ClientMetrics
 		scpu := r.ServerMetrics
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", ccpu.Idle), fmt.Sprintf("%f", ccpu.User), fmt.Sprintf("%f", ccpu.System), fmt.Sprintf("%f", ccpu.Steal), fmt.Sprintf("%f", ccpu.Iowait), fmt.Sprintf("%f", ccpu.Nice), fmt.Sprintf("%f", ccpu.Softirq), fmt.Sprintf("%f", ccpu.Irq),
 		})
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", scpu.Idle), fmt.Sprintf("%f", scpu.User), fmt.Sprintf("%f", scpu.System), fmt.Sprintf("%f", scpu.Steal), fmt.Sprintf("%f", scpu.Iowait), fmt.Sprintf("%f", scpu.Nice), fmt.Sprintf("%f", scpu.Softirq), fmt.Sprintf("%f", scpu.Irq),
 		})
 	}
@@ -243,15 +244,15 @@ func ShowNodeCPU(s ScenarioResults) {
 
 // ShowSpecificResults
 func ShowSpecificResults(s ScenarioResults) {
-	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
+	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, "TCP_STREAM") {
 			rt, _ := Average(r.RetransmitSummary)
-			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
+			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
 		}
 		if strings.Contains(r.Profile, "UDP_STREAM") {
 			loss, _ := Average(r.LossSummary)
-			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
+			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
 		}
 	}
 	table.Render()
@@ -259,7 +260,7 @@ func ShowSpecificResults(s ScenarioResults) {
 
 // Abstracts out the common code for results
 func renderResults(s ScenarioResults, testType string) {
-	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
+	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, testType) {
 			if len(r.Driver) > 0 {
@@ -268,7 +269,7 @@ func renderResults(s ScenarioResults, testType string) {
 				if r.Samples > 1 {
 					_, lo, hi = ConfidenceInterval(r.ThroughputSummary, 0.95)
 				}
-				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
+				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
 			}
 		}
 	}
@@ -297,11 +298,11 @@ func ShowRRResult(s ScenarioResults) {
 func ShowLatencyResult(s ScenarioResults) {
 	if checkResults(s, "RR") {
 		logging.Debug("Rendering RR P99 Latency results")
-		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
+		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
 				p99, _ := Average(r.LatencySummary)
-				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
+				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
 			}
 		}
 		table.Render()


### PR DESCRIPTION

## Type of change

- [ ] New feature

## Description
This commit allows communication between ocp internal pod and external server. k8s-netperf client pod will use the provided ip address as the destination ip address instead of ocp server pod address. To avoid code complexity, k8s-netperf still deploys all the assets i.e server pod and service etc, however it uses the ip address provided by the user as the destination to send the traffic instead of server pod address.

User has to manually configure the external server with the required k8s-netperf driver.

To communicate with external server which has the ip 44.243.95.221, user can call k8s-netperf like below
k8s-netperf --clean=false --debug --serverIP=44.243.95.221
