### PR TITLE
Updating the default VM image to quay.io/containerdisks/fedora:39

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -587,7 +587,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&json, "json", false, "Instead of human-readable output, return JSON to stdout")
 	rootCmd.Flags().BoolVar(&nl, "local", false, "Run network performance tests with Server-Pods/Client-Pods on the same Node")
 	rootCmd.Flags().BoolVar(&vm, "vm", false, "Launch Virtual Machines instead of pods for client/servers")
-	rootCmd.Flags().StringVar(&vmimage, "vm-image", "kubevirt/fedora-cloud-container-disk-demo:latest", "Use specified VM image")
+	rootCmd.Flags().StringVar(&vmimage, "vm-image", "quay.io/containerdisks/fedora:39", "Use specified VM image")
 	rootCmd.Flags().BoolVar(&acrossAZ, "across", false, "Place the client and server across availability zones")
 	rootCmd.Flags().BoolVar(&full, "all", false, "Run all tests scenarios - hostNet and podNetwork (if possible)")
 	rootCmd.Flags().BoolVar(&debug, "debug", false, "Enable debug log")


### PR DESCRIPTION

## Type of change


- [X] Bug fix

## Description

Starting from fedora 39, iperf3 is 3.16+ which is needed for having parallelism working.
Also, quay.io/containerdisks/fedora are public images that are not relying on Dockerhub.

## Checklist before requesting a review

- [] I have performed a self-review of my code.

## Testing
Tested with fedora 32 (I have left netperf driver result for comparison)
```
| 📊 Stream Results | netperf | TCP_STREAM | 4           | false        | false   | false           |          | 1024         | 0     | false     | 10       | 3       | 22236.963333 (Mb/s) | 21837.691487-22636.235180 (Mb/s) |
| 📊 Stream Results | iperf3  | TCP_STREAM | 4           | false        | false   | false           |          | 1024         | 0     | false     | 10       | 3       | 6077.609984 (Mb/s)  | 5281.149223-6874.070745 (Mb/s)   |

```

On fedora 39
```
| 📊 Stream Results | netperf | TCP_STREAM | 4           | false        | false   | false           |          | 1024         | 0     | false     | 10       | 3       | 21676.173333 (Mb/s) | 20484.782001-22867.564666 (Mb/s) |
| 📊 Stream Results | iperf3  | TCP_STREAM | 4           | false        | false   | false           |          | 1024         | 0     | false     | 10       | 3       | 18356.305237 (Mb/s) | 17719.515350-18993.095125 (Mb/s) |
```
