### PR TITLE
Changes outdated 'KIND_IPV*_SUPPORT' to 'PLATFORM_IPV*_SUPPORT'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
 
     env:
       KUBECONFIG: "/home/runner/ovn.conf"
-      KIND_IPV4_SUPPORT: "true"
-      KIND_IPV6_SUPPORT: "false"
+      PLATFORM_IPV4_SUPPORT: "true"
+      PLATFORM_IPV6_SUPPORT: "false"
       OVN_GATEWAY_MODE: "shared"
 
     steps:


### PR DESCRIPTION


## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the Kind setup of GH actions, the variables KIND_IPV*_SUPPORT has been changed 2 weeks ago in this commit:
https://github.com/ovn-kubernetes/ovn-kubernetes/commit/7d1d5b19b5a42dc5f2e6a10f041fc2f689fa2e16


## Checklist before requesting a review

- [X] I have performed a self-review of my code.

