### PR TITLE
Add support to use existing bridge NetworkAttachementDefinition

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -57,6 +57,7 @@ type Doc struct {
 	ClientVSwiitchMem float64          `json:"clientVswitchMem"`
 	ExternalServer    bool             `json:"externalServer"`
 	UdnInfo           string           `json:"udnInfo"`
+	BridgeInfo        string           `json:"bridgeInfo"`
 }
 
 // Connect returns a client connected to the desired cluster.
@@ -130,6 +131,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 			ClientNodeInfo:    r.ClientNodeInfo,
 			ServerNodeInfo:    r.ServerNodeInfo,
 			UdnInfo:           r.UdnInfo,
+			BridgeInfo:        r.BridgeInfo,
 		}
 		UDPLossPercent, e := result.Average(r.LossSummary)
 		if e != nil {
@@ -174,6 +176,7 @@ func commonCsvHeaderFields() []string {
 		"Service",
 		"External Server",
 		"UDN Info",
+		"Bridge Info",
 		"Duration",
 		"Parallelism",
 		"# of Samples",
@@ -198,6 +201,7 @@ func commonCsvDataFields(row result.Data) []string {
 		fmt.Sprint(row.Service),
 		fmt.Sprint(row.ExternalServer),
 		fmt.Sprint(row.UdnInfo),
+		fmt.Sprint(row.BridgeInfo),
 		strconv.Itoa(row.Duration),
 		strconv.Itoa(row.Parallelism),
 		strconv.Itoa(row.Samples),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,8 @@ type PerfScenarios struct {
 	VMHost              string
 	Udn                 bool
 	UdnPluginBinding    string
+	BridgeNetwork       string
+	BridgeNamespace     string
 	BridgeServerNetwork string
 	BridgeClientNetwork string
 	ServerNodeInfo      metrics.NodeInfo

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -61,11 +61,16 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 	id := uuid.New()
 	file := fmt.Sprintf("/tmp/iperf-%s", id.String())
 	pod := client.Items[0]
-	var clientIp string
+	clientIp := pod.Status.PodIP
+
 	if perf.Udn {
-		clientIp, _ = k8s.ExtractUdnIp(pod)
-	} else {
-		clientIp = pod.Status.PodIP
+		if udnIp, _ := k8s.ExtractUdnIp(pod); udnIp != "" {
+			clientIp = udnIp
+		}
+	} else if perf.BridgeNetwork != "" {
+		if bridgeClientIp, err := k8s.ExtractBridgeIp(pod, perf.BridgeNetwork, perf.BridgeNamespace); err == nil {
+			clientIp = bridgeClientIp
+		}
 	}
 	log.Debugf("🔥 Client (%s,%s) starting iperf3 against server: %s", pod.Name, clientIp, serverIP)
 	config.Show(nc, i.driverName)

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -48,6 +48,7 @@ type Data struct {
 	ServerPodMem      metrics.PodValues
 	ExternalServer    bool
 	UdnInfo           string
+	BridgeInfo        string
 }
 
 // ScenarioResults each scenario could have multiple results
@@ -193,13 +194,13 @@ func calDiff(a float64, b float64) float64 {
 
 // ShowPodCPU accepts ScenarioResults and presents to the user via stdout the PodCPU info
 func ShowPodCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -207,13 +208,13 @@ func ShowPodCPU(s ScenarioResults) {
 
 // ShowPodMem accepts ScenarioResults and presents to the user via stdout the Podmem info
 func ShowPodMem(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -221,7 +222,7 @@ func ShowPodMem(s ScenarioResults) {
 
 // ShowNodeCPU accepts ScenarioResults and presents to the user via stdout the NodeCPU info
 func ShowNodeCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
 	for _, r := range s.Results {
 		// Skip RR/CRR iperf3 Results
 		if strings.Contains(r.Profile, "RR") {
@@ -232,11 +233,11 @@ func ShowNodeCPU(s ScenarioResults) {
 		ccpu := r.ClientMetrics
 		scpu := r.ServerMetrics
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", ccpu.Idle), fmt.Sprintf("%f", ccpu.User), fmt.Sprintf("%f", ccpu.System), fmt.Sprintf("%f", ccpu.Steal), fmt.Sprintf("%f", ccpu.Iowait), fmt.Sprintf("%f", ccpu.Nice), fmt.Sprintf("%f", ccpu.Softirq), fmt.Sprintf("%f", ccpu.Irq),
 		})
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", scpu.Idle), fmt.Sprintf("%f", scpu.User), fmt.Sprintf("%f", scpu.System), fmt.Sprintf("%f", scpu.Steal), fmt.Sprintf("%f", scpu.Iowait), fmt.Sprintf("%f", scpu.Nice), fmt.Sprintf("%f", scpu.Softirq), fmt.Sprintf("%f", scpu.Irq),
 		})
 	}
@@ -245,15 +246,15 @@ func ShowNodeCPU(s ScenarioResults) {
 
 // ShowSpecificResults
 func ShowSpecificResults(s ScenarioResults) {
-	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
+	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, "TCP_STREAM") {
 			rt, _ := Average(r.RetransmitSummary)
-			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
+			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
 		}
 		if strings.Contains(r.Profile, "UDP_STREAM") {
 			loss, _ := Average(r.LossSummary)
-			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
+			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
 		}
 	}
 	table.Render()
@@ -261,7 +262,7 @@ func ShowSpecificResults(s ScenarioResults) {
 
 // Abstracts out the common code for results
 func renderResults(s ScenarioResults, testType string) {
-	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
+	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, testType) {
 			if len(r.Driver) > 0 {
@@ -270,7 +271,7 @@ func renderResults(s ScenarioResults, testType string) {
 				if r.Samples > 1 {
 					_, lo, hi = ConfidenceInterval(r.ThroughputSummary, 0.95)
 				}
-				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
+				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
 			}
 		}
 	}
@@ -299,11 +300,11 @@ func ShowRRResult(s ScenarioResults) {
 func ShowLatencyResult(s ScenarioResults) {
 	if checkResults(s, "RR") {
 		logging.Debug("Rendering RR P99 Latency results")
-		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
+		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
 				p99, _ := Average(r.LatencySummary)
-				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
+				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
 			}
 		}
 		table.Render()


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently the `--bridge` functionality only works when used together with `--vm`

## Related Tickets & Documents

- Closes #174

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
My system under test is a single MicroShift node.
- Please provide detailed steps to perform tests related to this code change.
```bash
# Simple - just reference your existing NAD
k8s-netperf --bridge bridge-conf

# Simple single node
k8s-netperf --bridge bridge-conf --local

# With custom namespace
k8s-netperf --bridge bridge-conf --bridgeNamespace specialnamespace

# With original VM support
k8s-netperf --vm --bridge my-bridge --bridgeNetwork bridgeNetwork.json
```
- Example execution
```
$ k8s-netperf --bridge bridge-conf --bridgeNamespace default --clean=true --config=smoke.yaml --debug=true --local=true --metrics=true --uuid=c0de5b05-1156-4f31-8b86-1b0e5031fbb4
WARN[2025-06-17 13:59:03] 😥 Prometheus is not available
INFO[2025-06-17 13:59:03] 🔨 Creating namespace: netperf
INFO[2025-06-17 13:59:03] 🔨 Creating service account: netperf
INFO[2025-06-17 13:59:03] ✅ Bridge network validation passed: default/bridge-conf
WARN[2025-06-17 13:59:03] ⚠️  No zone cabel
WARN[2025-06-17 13:59:03] ⚠️ ESingle node per zone and/or no zone labels
DEBU[2025-06-17 13:59:03] Number of nodes with role worker: 1
INFO[2025-06-17 13:59:03] 🌉 Configuring bridge network: default/bridge-conf
INFO[2025-06-17 13:59:03] 🚀 Starting Deployment for: client in namespace: netperf
INFO[2025-06-17 13:59:03] ⏰ Checking for client Pods to become ready...
INFO[2025-06-17 13:59:05] Looking for pods with label role=client-local
DEBU[2025-06-17 13:59:05] Machine with label role=client-local is Running on microshift with IP 192.168.2.133
DEBU[2025-06-17 13:59:05] Looking for service iperf-service in namespace netperf
INFO[2025-06-17 13:59:05] 🚀 Creating service for iperf-service in namespace netperf
DEBU[2025-06-17 13:59:05] Looking for service uperf-service in namespace netperf
INFO[2025-06-17 13:59:05] 🚀 Creating service for uperf-service in namespace netperf
DEBU[2025-06-17 13:59:05] Looking for service netperf-service in namespace netperf
INFO[2025-06-17 13:59:05] 🚀 Creating service for netperf-service in namespace netperf
INFO[2025-06-17 13:59:05] 🌉 Configuring bridge network: default/bridge-conf
INFO[2025-06-17 13:59:05] 🌉 Configuring bridge network: default/bridge-conf
INFO[2025-06-17 13:59:05] 🚀 Starting Deployment for: server in namespace: netperf
INFO[2025-06-17 13:59:05] ⏰ Checkng nfor server Pods to beeome ready...1
INFO[2025-06-17 13:59:08] Looking for pods with label role=server
DEBU[2025-06-17 13:59:08] Machine with label role=server is Running on microshift with IP 192.168.2.133
DEBU[2025-06-17 13:59:13] Pod server-56dbf845dd-7tgrn bridge network IP: 10.10.1.33
DEBU[2025-06-17 13:59:13] Using bridge network IP: 10.10.1.33 (interface: net1)
DEBU[2025-06-17 13:59:13] Executing workloads. hostNetwork is false, service is false, externalServer is false
DEBU[2025-06-17 13:59:13] Server IP: 10.10.1.33
DEBU[2025-06-17 13:59:13] Pod client-65cc8bf55c-jvvgr bridge network IP: 10.10.1.32
DEBU[2025-06-17 13:59:13] 🔥 Client (client-65cc8bf55c-jvvgr,10.10.1.32) starting netperf against server: 10.10.1.33
INFO[2025-06-17 13:59:13] 🗒️  Running netperf TCP_STREAM (service false) for 10s
DEBU[2025-06-17 13:59:13] [super-netperf 1 42424 -H 10.10.1.33 -l 10 -t TCP_STREAM -- -k rt_latency,p99_latency,throughput,throughput_units,remote_recv_calls,local_send_calls,local_transport_retrans -m 4096]
DEBU[2025-06-17 13:59:25] MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 42424 AF_INET to 10.10.1.33 () port 42424 AF_INET : demo
RT_LATENCY=-1
P99_LATENCY=4
THROUGHPUT=12512.74
LOCAL_TRANSPORT_RETRANS=0
REMOTE_RECV_CALLS=5194239
LOCAL_SEND_CALLS=3818600
THROUGHPUT_UNITS=10^6bits/s
DEBU[2025-06-17 13:59:25] Executing workloads. hostNetwork is false, service is true, externalServer is false
DEBU[2025-06-17 13:59:25] Server IP: 10.43.165.119
DEBU[2025-06-17 13:59:25] Pod client-65cc8bf55c-jvvgr bridge network IP: 10.10.1.32
DEBU[2025-06-17 13:59:25] 🔥 Client (client-65cc8bf55c-jvvgr,10.10.1.32) starting netperf against server: 10.43.165.119
INFO[2025-06-17 13:59:25] 🗒️  Running netperf TCP_STREAM (service true) for 10s
DEBU[2025-06-17 13:59:25] [super-netperf 1 42424 -H 10.43.165.119 -l 10 -t TCP_STREAM -- -k rt_latency,p99_latency,throughput,throughput_units,remote_recv_calls,local_send_calls,local_transport_retrans -m 4096]
DEBU[2025-06-17 13:59:37] MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 42424 AF_INET to 10.43.165.119 () port 42424 AF_INET : demo
RT_LATENCY=-1
P99_LATENCY=6
THROUGHPUT=9374.02
LOCAL_TRANSPORT_RETRANS=13
REMOTE_RECV_CALLS=3722422
LOCAL_SEND_CALLS=2860738
THROUGHPUT_UNITS=10^6bits/s
```