### PR TITLE
[PERFSCALE-4024] Add --hostNet flag

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -431,7 +431,7 @@ var rootCmd = &cobra.Command{
 		}
 		// Initially we are just checking against TCP_STREAM results.
 		retCode := 0
-		if result.CheckHostResults(sr) {
+		if !hostNetOnly && result.CheckHostResults(sr) {
 			diffs, err := result.TCPThroughputDiff(&sr)
 			if err != nil {
 				log.Error("Unable to calculate difference between HostNetwork and PodNetwork")

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -46,6 +46,7 @@ var (
 	udnPluginBinding string
 	acrossAZ         bool
 	full             bool
+	hostNetOnly      bool
 	vm               bool
 	vmimage          string
 	debug            bool
@@ -128,7 +129,8 @@ var rootCmd = &cobra.Command{
 			cleanup(client)
 		}
 		s := config.PerfScenarios{
-			HostNetwork:     full,
+			HostNetwork:     full || hostNetOnly,
+			HostNetworkOnly: hostNetOnly,
 			NodeLocal:       nl,
 			AcrossAZ:        acrossAZ,
 			RestConfig:      *rconfig,
@@ -290,9 +292,12 @@ var rootCmd = &cobra.Command{
 							sr.Results = append(sr.Results, pr)
 						}
 					}
-					pr = executeWorkload(nc, s, false, driver, false)
-					if len(pr.Profile) > 1 {
-						sr.Results = append(sr.Results, pr)
+					// Skip podNetwork tests if hostNetOnly is enabled
+					if !hostNetOnly {
+						pr = executeWorkload(nc, s, false, driver, false)
+						if len(pr.Profile) > 1 {
+							sr.Results = append(sr.Results, pr)
+						}
 					}
 				}
 			}
@@ -321,9 +326,12 @@ var rootCmd = &cobra.Command{
 							sr.Results = append(sr.Results, pr)
 						}
 					}
-					pr = executeWorkload(nc, s, false, driver, true)
-					if len(pr.Profile) > 1 {
-						sr.Results = append(sr.Results, pr)
+					// Skip podNetwork tests if hostNetOnly is enabled
+					if !hostNetOnly {
+						pr = executeWorkload(nc, s, false, driver, true)
+						if len(pr.Profile) > 1 {
+							sr.Results = append(sr.Results, pr)
+						}
 					}
 				}
 			}
@@ -636,10 +644,12 @@ func main() {
 	rootCmd.Flags().Uint32Var(&threads, "threads", 1, "Number of threads for VM")
 	rootCmd.Flags().BoolVar(&acrossAZ, "across", false, "Place the client and server across availability zones")
 	rootCmd.Flags().BoolVar(&full, "all", false, "Run all tests scenarios - hostNet and podNetwork (if possible)")
+	rootCmd.Flags().BoolVar(&hostNetOnly, "hostNet", false, "Run only hostNetwork tests (no podNetwork tests)")
 	rootCmd.Flags().BoolVar(&debug, "debug", false, "Enable debug log")
 	rootCmd.Flags().BoolVar(&udnl2, "udnl2", false, "Create and use a layer2 UDN as a primary network.")
 	rootCmd.Flags().BoolVar(&udnl3, "udnl3", false, "Create and use a layer3 UDN as a primary network.")
 	rootCmd.MarkFlagsMutuallyExclusive("udnl2", "udnl3")
+	rootCmd.MarkFlagsMutuallyExclusive("all", "hostNet")
 	rootCmd.Flags().StringVar(&udnPluginBinding, "udnPluginBinding", "passt", "UDN with VMs only - the binding method of the UDN interface, select 'passt' or 'l2bridge'")
 	rootCmd.Flags().StringVar(&bridge, "bridge", "", "Name of the NetworkAttachmentDefinition to be used for bridge interface")
 	rootCmd.Flags().StringVar(&bridgeNamespace, "bridgeNamespace", "default", "Namespace of the NetworkAttachmentDefinition for bridge interface")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type PerfScenarios struct {
 	NodeLocal           bool
 	AcrossAZ            bool
 	HostNetwork         bool
+	HostNetworkOnly     bool
 	ExternalServer      bool
 	Privileged          bool
 	Configs             []Config

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -535,15 +535,27 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				}
 			}
 		}
-		if !s.VM {
-			s.ClientAcross, err = deployDeployment(client, cdpAcross)
+		
+		// If HostNetworkOnly mode, get client node info from host network pods
+		if s.HostNetworkOnly && s.HostNetwork {
+			s.ClientNodeInfo, err = GetPodNodeInfo(client, labels.Set(cdpHostAcross.Labels).String())
 			if err != nil {
 				return err
 			}
-		} else {
-			err = launchClientVM(s, clientAcrossRole, &cdpAcross.PodAntiAffinity, &cdpHostAcross.NodeAffinity)
-			if err != nil {
-				return err
+		}
+		
+		// Only create regular client pods if not in HostNetworkOnly mode
+		if !s.HostNetworkOnly {
+			if !s.VM {
+				s.ClientAcross, err = deployDeployment(client, cdpAcross)
+				if err != nil {
+					return err
+				}
+			} else {
+				err = launchClientVM(s, clientAcrossRole, &cdpAcross.PodAntiAffinity, &cdpHostAcross.NodeAffinity)
+				if err != nil {
+					return err
+				}
 			}
 		}
 
@@ -658,26 +670,37 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				}
 			}
 		}
+		
+		// If HostNetworkOnly mode, get server node info from host network pods
+		if s.HostNetworkOnly && s.HostNetwork {
+			s.ServerNodeInfo, err = GetPodNodeInfo(client, labels.Set(sdpHost.Labels).String())
+			if err != nil {
+				return err
+			}
+		}
 	}
-	if !s.VM {
-		s.Server, err = deployDeployment(client, sdp)
-		if err != nil {
-			return err
-		}
-		s.ServerNodeInfo, err = GetPodNodeInfo(client, labels.Set(sdp.Labels).String())
-		if err != nil {
-			return err
-		}
-		if !s.NodeLocal {
-			s.ClientNodeInfo, err = GetPodNodeInfo(client, labels.Set(cdpAcross.Labels).String())
-		}
-		if err != nil {
-			return err
-		}
-	} else {
-		err = launchServerVM(s, serverRole, &sdp.PodAntiAffinity, &sdp.NodeAffinity)
-		if err != nil {
-			return err
+	// Only create regular server pods if not in HostNetworkOnly mode
+	if !s.HostNetworkOnly {
+		if !s.VM {
+			s.Server, err = deployDeployment(client, sdp)
+			if err != nil {
+				return err
+			}
+			s.ServerNodeInfo, err = GetPodNodeInfo(client, labels.Set(sdp.Labels).String())
+			if err != nil {
+				return err
+			}
+			if !s.NodeLocal {
+				s.ClientNodeInfo, err = GetPodNodeInfo(client, labels.Set(cdpAcross.Labels).String())
+			}
+			if err != nil {
+				return err
+			}
+		} else {
+			err = launchServerVM(s, serverRole, &sdp.PodAntiAffinity, &sdp.NodeAffinity)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a `--hostNet` flag that only creates hostNetworking pods (and not regular podNetworking pods). The flag is defined as mutually exclusive with the `--all` one.

## Related Tickets & Documents

This is a pre-req for the RoCE functionality, that does not work on regular podNetwork pods.

## Testing
```
$ bin/amd64/k8s-netperf --config netperf2.yml --hostNet
INFO[2025-08-25 10:50:55] Starting k8s-netperf (hostnet2@a86ec193cbf5c0a15445549a0773d10f30aab14c)
INFO[2025-08-25 10:50:55] 📒 Reading netperf2.yml file.
INFO[2025-08-25 10:50:55] 📒 Reading netperf2.yml file - using ConfigV2 Method.
W0825 10:50:55.829762  267628 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W0825 10:50:55.829773  267628 client_config.go:623] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
ERRO[2025-08-25 10:50:55] invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
WARN[2025-08-25 10:50:55] 😥 Prometheus is not available
INFO[2025-08-25 10:50:55] 🔨 Creating namespace: netperf
INFO[2025-08-25 10:50:55] 🔨 Creating service account: netperf
WARN[2025-08-25 10:50:55] ⚠️  No zone label
WARN[2025-08-25 10:50:55] ⚠️  Single node per zone and/or no zone labels
INFO[2025-08-25 10:50:55] 🚀 Creating service for iperf-service in namespace netperf
INFO[2025-08-25 10:50:56] 🚀 Creating service for uperf-service in namespace netperf
INFO[2025-08-25 10:50:56] 🚀 Creating service for netperf-service in namespace netperf
INFO[2025-08-25 10:50:57] 🚀 Starting Deployment for: client-host in namespace: netperf
INFO[2025-08-25 10:50:57] ⏰ Checking for client-host Pods to become ready...
^[[OINFO[2025-08-25 10:50:58] Looking for pods with label role=host-client
INFO[2025-08-25 10:50:58] 🚀 Starting Deployment for: server-host in namespace: netperf
INFO[2025-08-25 10:50:58] ⏰ Checking for server-host Pods to become ready...
INFO[2025-08-25 10:51:02] Looking for pods with label role=host-server
INFO[2025-08-25 10:51:07] 🗒️  Running netperf TCP_STREAM (service false) for 5s
WARN[2025-08-25 10:51:14] Not able to collect OpenShift specific node info
+-------------------+---------+------------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+--------------------+--------------------------+
|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG VALUE      | 95% CONFIDENCE INTERVAL  |
+-------------------+---------+------------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+--------------------+--------------------------+
| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | false           |          |             | 1024         | 0     | false     | 5        | 1       | 2558.970000 (Mb/s) | 0.000000-0.000000 (Mb/s) |
+-------------------+---------+------------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+--------------------+--------------------------+
+---------------------+---------+------------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+-----------+
|        TYPE         | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES | AVG VALUE |
+---------------------+---------+------------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+-----------+
| TCP Retransmissions | netperf | TCP_STREAM | 1           | true         | false   | false           |          |             | 1024         | 0     | false     | 5        | 1       | 1.000000  |
+---------------------+---------+------------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+-----------+
ERRO[2025-08-25 10:51:14] 😥 TCP Single Stream (Message Size : 1024) percent difference when comparing hostNetwork to podNetwork is greater than 10.0 percent (200.0 percent) for 1 streams
INFO[2025-08-25 10:51:14] Cleaning resources created by k8s-netperf
INFO[2025-08-25 10:51:14] ⏰ Waiting for netperf Namespace to be deleted...

# During the test
$ kubectl get po -n netperf
NAME                             READY   STATUS    RESTARTS   AGE
client-host-68d49b6c74-qwpth     1/1     Running   0          15s
server-host-6dbc65dd87-s5gwb     3/3     Running   0          11s
```
