### PR TITLE
Run build-container on PRs

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "containers/**" # Trigger only when Dockerfile changes in a pull request
   pull_request:
+    branches: [ "*" ]
     paths:
       - "containers/**" # Trigger only when Dockerfile changes in a pull request
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - "containers/**" # Trigger only when Dockerfile changes in a pull request
+  pull_request:
+    paths:
+      - "containers/**" # Trigger only when Dockerfile changes in a pull request
 
 env:
   CONTAINER_REGISTRY: ${{ 'quay.io' }}
@@ -18,7 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     steps:
       - name: Setup QEMU & Install Dependecies
         run: |


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

The build-container workflow is only being run when the Containerfile is pushed to main. We need to run it in the pull request itself before merging.