### PR TITLE
uperf: Fix reporting of ops/s

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -576,7 +576,7 @@ func executeWorkload(nc config.Config,
 	}
 	npr.Driver = driverName
 	// Check if test is supported
-	if !driver.IsTestSupported(nc.Profile) {
+	if !driver.IsTestSupported() {
 		log.Warnf("Test %s is not supported with driver %s. Skipping.", nc.Profile, npr.Driver)
 		return npr
 	}

--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/config"
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/sample"
@@ -18,32 +19,40 @@ type Driver interface {
 
 type netperf struct {
 	driverName string
+	testConfig config.Config
 }
 
 type iperf3 struct {
 	driverName string
+	testConfig config.Config
 }
 
 type uperf struct {
 	driverName string
+	testConfig config.Config
 }
 
-// NewDriver creates a new driver based on the provided driver name.
-//
-// It takes a string parameter `driverName` and returns a Driver.
-func NewDriver(driverName string) Driver {
+// NewDriver returns a Driver based on the given driverName and configuration.
+// It currently supports the "iperf3", "uperf", and "netperf" drivers.
+// If the driverName is not recognized, it returns an error.
+func NewDriver(driverName string, cfg config.Config) (Driver, error) {
 	switch driverName {
 	case "iperf3":
 		return &iperf3{
 			driverName: driverName,
-		}
+			testConfig: cfg,
+		}, nil
 	case "uperf":
 		return &uperf{
 			driverName: driverName,
-		}
-	default:
+			testConfig: cfg,
+		}, nil
+	case "netperf":
 		return &netperf{
 			driverName: driverName,
-		}
+			testConfig: cfg,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown driver: %s", driverName)
 	}
 }

--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Driver interface {
-	IsTestSupported(string) bool
+	IsTestSupported() bool
 	Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1.PodList, serverIP string, perf *config.PerfScenarios) (bytes.Buffer, error)
 	ParseResults(stdout *bytes.Buffer, nc config.Config) (sample.Sample, error)
 }

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -39,8 +39,8 @@ type IperfResult struct {
 }
 
 // IsTestSupported Determine if the test is supported for driver
-func (i *iperf3) IsTestSupported(test string) bool {
-	return strings.Contains(test, "STREAM")
+func (i *iperf3) IsTestSupported() bool {
+	return strings.Contains(i.testConfig.Profile, "STREAM")
 }
 
 // Run will invoke iperf3 in a client container

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -23,14 +23,6 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-var Iperf iperf3
-
-func init() {
-	Iperf = iperf3{
-		driverName: "iperf",
-	}
-}
-
 type IperfResult struct {
 	Data struct {
 		TCPRetransmit struct {

--- a/pkg/drivers/netperf.go
+++ b/pkg/drivers/netperf.go
@@ -21,14 +21,6 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-var Netperf netperf
-
-func init() {
-	Netperf = netperf{
-		driverName: "netperf",
-	}
-}
-
 const superNetperf = "super-netperf"
 
 // omniOptions are netperf specific options that we will pass to the netperf client.

--- a/pkg/drivers/netperf.go
+++ b/pkg/drivers/netperf.go
@@ -200,6 +200,6 @@ func (n *netperf) ParseResults(stdout *bytes.Buffer, _ config.Config) (sample.Sa
 }
 
 // IsTestSupported Determine if the test is supported for driver
-func (n *netperf) IsTestSupported(test string) bool {
+func (n *netperf) IsTestSupported() bool {
 	return true
 }

--- a/pkg/drivers/uperf.go
+++ b/pkg/drivers/uperf.go
@@ -38,8 +38,8 @@ type Result struct {
 }
 
 // TestSupported Determine if the test is supported for driver
-func (u *uperf) IsTestSupported(test string) bool {
-	return !strings.Contains(test, "TCP_CRR")
+func (u *uperf) IsTestSupported() bool {
+	return !strings.Contains(u.testConfig.Profile, "TCP_CRR")
 }
 
 // uperf needs "rr" or "stream" profiles which are config files passed to uperf command through -m option


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Throughput in k8s-netperf terms is the number of ops/s rather than bps, Without this fix the reported number of operations per second was incorrect:

Using this config
```yaml
tests:
- RRService-TCP:
  parallelism: 1
  profile: "TCP_RR"
  duration: 30
  samples: 1
  messagesize: 1024
  service: true

- RRService-TCP2:
  parallelism: 4
  profile: "TCP_RR"
  duration: 30
  samples: 1
  messagesize: 1024
  service: true

```
No fix

```shell
+---------------+--------+----------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+-------------------+--------------------------+                
|  RESULT TYPE  | DRIVER | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG VALUE     | 95% CONFIDENCE INTERVAL  |                
+---------------+--------+----------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+-------------------+--------------------------+                
| 📊 Rr Results | uperf  | TCP_RR   | 1           | false        | true    | false           |          |             | 1024         | 0     | false     | 30       | 1       | 20.199014 (OP/s)  | 0.000000-0.000000 (OP/s) |  
| 📊 Rr Results | uperf  | TCP_RR   | 4           | false        | true    | false           |          |             | 1024         | 0     | false     | 30       | 1       | 80.773120 (OP/s)  | 0.000000-0.000000 (OP/s) |                
| 📊 Rr Results | uperf  | TCP_RR   | 16          | false        | true    | false           |          |             | 1024         | 0     | false     | 30       | 1       | 319.530325 (OP/s) | 0.000000-0.000000 (OP/s) |  
+---------------+--------+----------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+-------------------+--------------------------+      
```


Fixed version
```
+---------------+--------+----------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+              
|  RESULT TYPE  | DRIVER | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |      AVG VALUE      | 95% CONFIDENCE INTERVAL  |              
+---------------+--------+----------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+              
| 📊 Rr Results | uperf  | TCP_RR   | 1           | false        | true    | false           |          |             | 1024         | 0     | false     | 30       | 1       | 2480.366667 (OP/s)  | 0.000000-0.000000 (OP/s) |
| 📊 Rr Results | uperf  | TCP_RR   | 4           | false        | true    | false           |          |             | 1024         | 0     | false     | 30       | 1       | 10011.066667 (OP/s) | 0.000000-0.000000 (OP/s) |
| 📊 Rr Results | uperf  | TCP_RR   | 16          | false        | true    | false           |          |             | 1024         | 0     | false     | 30       | 1       | 39401.133333 (OP/s) | 0.000000-0.000000 (OP/s) |
+---------------+--------+----------+-------------+--------------+---------+-----------------+----------+-------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+

```

## Related Tickets & Documents

- Related Issue #
- Closes #
