### PR TITLE
Add quick install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ A tool to run network performance tests in Kubernetes clusters.
 
 ## Quick Start
 
+Install latest stable version with:
+
 ```shell
-$ git clone http://github.com/cloud-bulldozer/k8s-netperf
-$ cd k8s-netperf
-$ make build
+curl -Ls https://raw.githubusercontent.com/cloud-bulldozer/k8s-netperf/refs/heads/main/hack/install.sh | sh
+```
+
+> [!NOTE]
+> Default installation path is `${HOME}/.local/bin/`, you can change it by setting the `INSTALL_DIR` environment variable to the desired path.
+> before running the script
+
+Then create the required resources:
+```shell
 $ kubectl create ns netperf
 $ kubectl create sa netperf -n netperf
-$ ./bin/amd64/k8s-netperf --config netperf.yml
+$ k8s-netperf --config netperf.yml
 ```
 
 ## Documentation

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086 
+# Quick install script for k8s-netperf
+# Downloads the latest release version based on system architecture and OS
+
+set -euo pipefail
+
+# Configuration
+REPO="cloud-bulldozer/k8s-netperf"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin/}"
+
+# Detect OS
+detect_os() {
+  local os
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  
+  case "${os}" in
+    linux*)
+      echo "linux"
+      ;;
+    darwin*)
+      echo "darwin"
+      ;;
+    mingw* | msys* | cygwin*)
+      echo "windows"
+      ;;
+    *)
+      echo "Unsupported operating system: ${os}"
+      exit 1
+      ;;
+  esac
+}
+
+# Get latest release version from GitHub
+get_latest_version() {
+  local version
+  if command -v curl &> /dev/null; then
+    version=$(curl -sL "https://api.github.com/repos/${REPO}/releases/latest" | \
+              grep '"tag_name":' | \
+              sed -E 's/.*"([^"]+)".*/\1/')
+  else
+    echo "curl command not found. Please install it."
+    exit 1
+  fi
+  
+  if [[ -z "${version}" ]]; then
+    echo "Failed to fetch latest version"
+    exit 1
+  fi
+  
+  echo "${version}"
+}
+
+# Download and extract binary
+download_and_extract() {
+  local version=$1
+  local os=$2
+  local arch=$3
+  local archive_name="k8s-netperf_${os}_${version}_${arch}.tar.gz"
+  local download_url="https://github.com/${REPO}/releases/download/${version}/${archive_name}"
+  mkdir -p ${INSTALL_DIR}
+  echo "Downloading k8s-netperf ${version} for ${os}/${arch}..."
+  echo "URL: ${download_url}"
+  curl -sL -f "${download_url}" | tar xz -C ${INSTALL_DIR} k8s-netperf
+}
+
+# Verify installation
+verify_installation() {
+  if command -v k8s-netperf &> /dev/null; then
+    echo "k8s-netperf is now available in your PATH, installed at ${INSTALL_DIR}"
+  else
+    echo "k8s-netperf installed to ${INSTALL_DIR}, but not found in PATH"
+    echo "You may need to add ${INSTALL_DIR} to your PATH"
+  fi
+}
+
+# Main installation flow
+main() {
+  echo "Starting k8s-netperf 🔥 installation..."
+  
+  # Detect system   
+  local os
+  local arch
+  os=$(detect_os)
+  arch=$(uname -m | sed s/aarch64/arm64/)
+  
+  echo "Detected system: ${os}/${arch}"
+  
+  # Get latest version
+  local version
+  version=$(get_latest_version)
+  echo "Latest version: ${version}"
+  
+  # Download and extract
+  download_and_extract "${version}" "${os}" "${arch}"
+  
+  # Verify
+  verify_installation
+  
+  echo "Get started with: k8s-netperf help"
+}
+
+# Run main function
+main "$@"
+


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Adding quick-install script

```bash
rsevilla@fedora ~/labs/k8s-netperf (main) $ ./hack/install.sh 
Starting k8s-netperf 🔥 installation...
Detected system: linux/x86_64
Latest version: v0.1.34
Downloading k8s-netperf v0.1.34 for linux/x86_64...
URL: https://github.com/cloud-bulldozer/k8s-netperf/releases/download/v0.1.34/k8s-netperf_linux_v0.1.34_x86_64.tar.gz
k8s-netperf is now available in your PATH, installed at /var/home/rsevilla/.local/bin/
Get started with: k8s-netperf help
rsevilla@fedora ~/labs/k8s-netperf (main) $ k8s-netperf --help
A tool to run network performance tests in Kubernetes cluster

Usage:
  k8s-netperf [flags]

Flags:
      --config string             K8s netperf Configuration File (default "netperf.yml")
      --netperf                   Use netperf as load driver (default true)
      --iperf                     Use iperf3 as load driver
      --uperf                     Use uperf as load driver
      --clean                     Clean-up resources created by k8s-netperf (default true)
      --json                      Instead of human-readable output, return JSON to stdout
      --local                     Run network performance tests with Server-Pods/Client-Pods on the same Node
blablabla
```