### PR TITLE
Seperate Pod and VM execution

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -380,7 +380,7 @@ var rootCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			s.VMClient = vmClient
+			s.VMClientExecutor = vmClient
 
 			// Also set SSHClient for backward compatibility if using SSH
 			if !s.UseVirtctl {
@@ -660,10 +660,18 @@ func executeWorkload(nc config.Config,
 		}
 	}
 	if !s.NodeLocal && !s.ExternalServer {
-		Client = s.ClientAcross
+		if virt {
+			Client = s.VMClientAcross
+		} else {
+			Client = s.ClientAcross
+		}
 	}
 	if hostNet && !s.NodeLocal {
-		Client = s.ClientHost
+		if virt {
+			Client = s.VMClientHost
+		} else {
+			Client = s.ClientHost
+		}
 	}
 	npr.Config = nc
 	npr.Metric = nc.Metric

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -653,10 +653,18 @@ func executeWorkload(nc config.Config,
 		serverIP = strings.Split(s.BridgeServerNetwork, "/")[0]
 		npr.BridgeInfo = fmt.Sprintf("VM Bridge (%s)", serverIP)
 	} else {
-		if hostNet && !s.NodeLocal {
-			serverIP = s.ServerHost.Items[0].Status.PodIP
+		if virt {
+			if hostNet && !s.NodeLocal {
+				serverIP = s.VMServerHost.Items[0].Status.PodIP
+			} else {
+				serverIP = s.VMServer.Items[0].Status.PodIP
+			}
 		} else {
-			serverIP = s.Server.Items[0].Status.PodIP
+			if hostNet && !s.NodeLocal {
+				serverIP = s.ServerHost.Items[0].Status.PodIP
+			} else {
+				serverIP = s.Server.Items[0].Status.PodIP
+			}
 		}
 	}
 	if !s.NodeLocal && !s.ExternalServer {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,10 +66,15 @@ type PerfScenarios struct {
 	ServerNodeInfo      metrics.NodeInfo
 	ClientNodeInfo      metrics.NodeInfo
 	Client              apiv1.PodList
+	VMClient            apiv1.PodList
 	Server              apiv1.PodList
+	VMServer            apiv1.PodList
 	ClientAcross        apiv1.PodList
+	VMClientAcross      apiv1.PodList
 	ClientHost          apiv1.PodList
+	VMClientHost        apiv1.PodList
 	ServerHost          apiv1.PodList
+	VMServerHost        apiv1.PodList
 	NetperfService      *apiv1.Service
 	IperfService        *apiv1.Service
 	UperfService        *apiv1.Service
@@ -78,7 +83,7 @@ type PerfScenarios struct {
 	KClient             *kubevirtv1.KubevirtV1Client
 	DClient             *dynamic.DynamicClient
 	SSHClient           *goph.Client
-	VMClient            VMExecutor
+	VMClientExecutor    VMExecutor
 }
 
 // struct for bridge options

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -98,7 +98,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 	}
 	log.Debug(cmd)
 	// Pod mode
-	if !strings.Contains(pod.Name, "virt") {
+	if !perf.VM {
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).
@@ -174,7 +174,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 	stderr = bytes.Buffer{}
 
 	// Pod mode
-	if !strings.Contains(pod.Name, "virt") {
+	if !perf.VM {
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -97,7 +97,8 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 		}
 	}
 	log.Debug(cmd)
-	if !perf.VM {
+	// Pod mode
+	if !strings.Contains(pod.Name, "virt") {
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).
@@ -125,6 +126,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 		if err != nil {
 			return stdout, err
 		}
+		// VM mode
 	} else {
 		retry := 10
 		present := false
@@ -171,7 +173,8 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	if !perf.VM {
+	// Pod mode
+	if !strings.Contains(pod.Name, "virt") {
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).
@@ -201,6 +204,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 		}
 		log.Debug(strings.TrimSpace(stdout.String()))
 		return stdout, nil
+		// VM mode
 	} else {
 		sshclient, err := k8s.SSHConnect(perf)
 		if err != nil {

--- a/pkg/drivers/netperf.go
+++ b/pkg/drivers/netperf.go
@@ -75,7 +75,8 @@ func (n *netperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config,
 	}
 	cmd = append(cmd, additionalOptions...)
 	log.Debug(cmd)
-	if !perf.VM {
+	// Pod mode
+	if !strings.Contains(pod.Name, "virt") {
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).
@@ -105,13 +106,14 @@ func (n *netperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config,
 		}
 		log.Debug(strings.TrimSpace(stdout.String()))
 		return stdout, nil
+		// VM mode
 	} else {
 		retry := 10
 		present := false
 
 		var vmClient config.VMExecutor
-		if perf.VMClient != nil {
-			vmClient = perf.VMClient
+		if perf.VMClientExecutor != nil {
+			vmClient = perf.VMClientExecutor
 		} else {
 			sshclient, err := k8s.SSHConnect(perf)
 			if err != nil {

--- a/pkg/drivers/netperf.go
+++ b/pkg/drivers/netperf.go
@@ -76,7 +76,7 @@ func (n *netperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config,
 	cmd = append(cmd, additionalOptions...)
 	log.Debug(cmd)
 	// Pod mode
-	if !strings.Contains(pod.Name, "virt") {
+	if !perf.VM {
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).

--- a/pkg/drivers/uperf.go
+++ b/pkg/drivers/uperf.go
@@ -93,7 +93,7 @@ func createUperfProfile(c *kubernetes.Clientset, rc rest.Config, nc config.Confi
 	stdout = bytes.Buffer{}
 
 	// Pod mode
-	if !strings.Contains(pod.Name, "virt") {
+	if !perf.VM {
 		var cmd []string
 		uperfCmd := "echo '" + fileContent + "' > " + filePath
 		cmd = []string{"bash", "-c", uperfCmd}
@@ -196,7 +196,7 @@ func (u *uperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, c
 	log.Debug(cmd)
 
 	// Pod mode
-	if !strings.Contains(pod.Name, "virt") {
+	if !perf.VM {
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -940,12 +940,12 @@ func launchServerVM(perf *config.PerfScenarios, name string, podAff *corev1.PodA
 	}
 
 	if strings.Contains(name, "host") {
-		perf.ServerHost, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", serverRole))
+		perf.VMServerHost, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", serverRole))
 		if err != nil {
 			return err
 		}
 	} else {
-		perf.Server, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", serverRole))
+		perf.VMServer, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", serverRole))
 		if err != nil {
 			return err
 		}
@@ -968,12 +968,12 @@ func launchClientVM(perf *config.PerfScenarios, name string, podAff *corev1.PodA
 		return err
 	}
 	if strings.Contains(name, "host") {
-		perf.ClientHost, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", name))
+		perf.VMClientHost, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", name))
 		if err != nil {
 			return err
 		}
 	} else {
-		perf.ClientAcross, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", name))
+		perf.VMClientAcross, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", name))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Type of change

- [X] Bug fix

## Description

Use dedicated variables for VM-client and VM-server to ensure tests are run from the pod-client or the VM-client

## Related Tickets & Documents

- Related Issue # https://github.com/cloud-bulldozer/k8s-netperf/issues/226

## Checklist before requesting a review

- [X] I have performed a self-review of my code.

