### PR TITLE
Fixing deployments of VMs when --all is enable 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       
       - name: Run default tests
         run: |
-          ./bin/amd64/k8s-netperf --debug --all
+          ./bin/amd64/k8s-netperf --debug --all --tcp-tolerance 100
 
       - name: Run UDN L3 tests (using SVC)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       
       - name: Run default tests
         run: |
-          ./bin/amd64/k8s-netperf --debug
+          ./bin/amd64/k8s-netperf --debug --all
 
       - name: Run UDN L3 tests (using SVC)
         run: |

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -382,14 +382,6 @@ var rootCmd = &cobra.Command{
 			}
 			s.VMClientExecutor = vmClient
 
-			// Also set SSHClient for backward compatibility if using SSH
-			if !s.UseVirtctl {
-				sshClient, err := k8s.SSHConnect(&s)
-				if err != nil {
-					log.Fatal(err)
-				}
-				s.SSHClient = sshClient
-			}
 			for _, nc := range s.Configs {
 				// Determine the metric for the test
 				metric := string("OP/s")

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -693,7 +693,7 @@ func executeWorkload(nc config.Config,
 		npr.AcrossAZ = nc.AcrossAZ
 	}
 	npr.StartTime = time.Now()
-	log.Debugf("Executing workloads. hostNetwork is %t, service is %t, externalServer is %t", hostNet, nc.Service, npr.ExternalServer)
+	log.Debugf("Executing workloads. hostNetwork is %t, service is %t, externalServer is %t, VM mode is %t", hostNet, nc.Service, npr.ExternalServer, virt)
 	driver, err = drivers.NewDriver(driverName, nc)
 	if err != nil {
 		log.Fatal(err)
@@ -706,7 +706,7 @@ func executeWorkload(nc config.Config,
 	}
 	for i := 0; i < nc.Samples; i++ {
 		nr := sample.Sample{}
-		r, err := driver.Run(s.ClientSet, s.RestConfig, nc, Client, serverIP, &s)
+		r, err := driver.Run(s.ClientSet, s.RestConfig, nc, Client, serverIP, &s, virt)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -718,7 +718,7 @@ func executeWorkload(nc config.Config,
 			// Retry the current test.
 			for try < retry {
 				log.Warn("Rerunning test.")
-				r, err := driver.Run(s.ClientSet, s.RestConfig, nc, Client, serverIP, &s)
+				r, err := driver.Run(s.ClientSet, s.RestConfig, nc, Client, serverIP, &s, virt)
 				if err != nil {
 					log.Error(err)
 					continue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,12 +72,13 @@ type PerfScenarios struct {
 	ClientAcross        apiv1.PodList
 	VMClientAcross      apiv1.PodList
 	ClientHost          apiv1.PodList
-	VMClientHost        apiv1.PodList
 	ServerHost          apiv1.PodList
-	VMServerHost        apiv1.PodList
 	NetperfService      *apiv1.Service
 	IperfService        *apiv1.Service
 	UperfService        *apiv1.Service
+	NetperfVmService    *apiv1.Service
+	IperfVmService      *apiv1.Service
+	UperfVmService      *apiv1.Service
 	RestConfig          rest.Config
 	ClientSet           *kubernetes.Clientset
 	KClient             *kubevirtv1.KubevirtV1Client

--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -13,7 +13,7 @@ import (
 
 type Driver interface {
 	IsTestSupported() bool
-	Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1.PodList, serverIP string, perf *config.PerfScenarios) (bytes.Buffer, error)
+	Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1.PodList, serverIP string, perf *config.PerfScenarios, virt bool) (bytes.Buffer, error)
 	ParseResults(stdout *bytes.Buffer, nc config.Config) (sample.Sample, error)
 }
 

--- a/pkg/drivers/ibwritebw.go
+++ b/pkg/drivers/ibwritebw.go
@@ -5,12 +5,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/config"
-	"github.com/cloud-bulldozer/k8s-netperf/pkg/k8s"
 	log "github.com/cloud-bulldozer/k8s-netperf/pkg/logging"
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/sample"
 	"k8s.io/client-go/kubernetes"
@@ -87,30 +85,7 @@ func (i *ibWriteBw) Run(c *kubernetes.Clientset,
 	log.Debug(cmd)
 	//
 	if virt {
-		retry := 3
-		sshclient, err := k8s.SSHConnect(perf)
-		if err != nil {
-			return stdout, err
-		}
-		var stdoutBytes []byte
-		ran := false
-		for i := 0; i <= retry; i++ {
-			stdoutBytes, err = sshclient.Run(strings.Join(cmd[:], " "))
-			if err == nil {
-				ran = true
-				break
-			}
-			log.Debugf("Failed running command %s", err)
-			log.Debugf("⏰ Retrying ib_write_bw command -- cloud-init still finishing up")
-			time.Sleep(60 * time.Second)
-		}
-		if err := sshclient.Close(); err != nil {
-			log.Debugf("Failed to close SSH client: %v", err)
-		}
-		if !ran {
-			return *bytes.NewBuffer(stdoutBytes), fmt.Errorf("unable to run ib_write_bw")
-		}
-		stdout = *bytes.NewBuffer(stdoutBytes)
+		log.Info("IB Write BW is not supported for VM mode... skipping")
 	} else {
 		//Pod mode
 		req := c.CoreV1().RESTClient().

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -97,7 +97,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 		}
 	}
 	log.Debug(cmd)
-	// Pod mode
+	// Vm mode
 	if virt {
 		retry := 10
 		present := false
@@ -138,30 +138,6 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 		if !ran {
 			return *bytes.NewBuffer(stdout), fmt.Errorf("unable to run iperf3")
 		}
-	}
-
-	//Empty buffer
-	stdout = bytes.Buffer{}
-	stderr = bytes.Buffer{}
-
-	// VM mode
-	if virt {
-		sshclient, err := k8s.SSHConnect(perf)
-		if err != nil {
-			return stdout, err
-		}
-		stdout, err := sshclient.Run(fmt.Sprintf("cat %s", file))
-		if err != nil {
-			if closeErr := sshclient.Close(); closeErr != nil {
-				log.Warnf("Error closing SSH client: %v", closeErr)
-			}
-			return *bytes.NewBuffer(stdout), err
-		}
-		log.Debug(strings.TrimSpace(bytes.NewBuffer(stdout).String()))
-		if err := sshclient.Close(); err != nil {
-			log.Warnf("Error closing SSH client: %v", err)
-		}
-		return *bytes.NewBuffer(stdout), nil
 	} else {
 		//Pod mode
 		req := c.CoreV1().RESTClient().
@@ -194,6 +170,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 		log.Debug(strings.TrimSpace(stdout.String()))
 		return stdout, nil
 	}
+	return stdout, nil
 }
 
 // ParseResults accepts the stdout from the execution of the benchmark.

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -48,7 +48,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 	rc rest.Config,
 	nc config.Config,
 	client apiv1.PodList,
-	serverIP string, perf *config.PerfScenarios) (bytes.Buffer, error) {
+	serverIP string, perf *config.PerfScenarios, virt bool) (bytes.Buffer, error) {
 	var stdout, stderr bytes.Buffer
 	id := uuid.New()
 	file := fmt.Sprintf("/tmp/iperf-%s", id.String())
@@ -98,36 +98,7 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 	}
 	log.Debug(cmd)
 	// Pod mode
-	if !perf.VM {
-		req := c.CoreV1().RESTClient().
-			Post().
-			Namespace(pod.Namespace).
-			Resource("pods").
-			Name(pod.Name).
-			SubResource("exec").
-			VersionedParams(&apiv1.PodExecOptions{
-				Container: pod.Spec.Containers[0].Name,
-				Command:   cmd,
-				Stdin:     false,
-				Stdout:    true,
-				Stderr:    true,
-				TTY:       true,
-			}, scheme.ParameterCodec)
-		exec, err := remotecommand.NewSPDYExecutor(&rc, "POST", req.URL())
-		if err != nil {
-			return stdout, err
-		}
-		// Connect this process' std{in,out,err} to the remote shell process.
-		err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
-			Stdin:  nil,
-			Stdout: &stdout,
-			Stderr: &stderr,
-		})
-		if err != nil {
-			return stdout, err
-		}
-		// VM mode
-	} else {
+	if virt {
 		retry := 10
 		present := false
 		sshclient, err := k8s.SSHConnect(perf)
@@ -173,8 +144,26 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	// Pod mode
-	if !perf.VM {
+	// VM mode
+	if virt {
+		sshclient, err := k8s.SSHConnect(perf)
+		if err != nil {
+			return stdout, err
+		}
+		stdout, err := sshclient.Run(fmt.Sprintf("cat %s", file))
+		if err != nil {
+			if closeErr := sshclient.Close(); closeErr != nil {
+				log.Warnf("Error closing SSH client: %v", closeErr)
+			}
+			return *bytes.NewBuffer(stdout), err
+		}
+		log.Debug(strings.TrimSpace(bytes.NewBuffer(stdout).String()))
+		if err := sshclient.Close(); err != nil {
+			log.Warnf("Error closing SSH client: %v", err)
+		}
+		return *bytes.NewBuffer(stdout), nil
+	} else {
+		//Pod mode
 		req := c.CoreV1().RESTClient().
 			Post().
 			Namespace(pod.Namespace).
@@ -204,24 +193,6 @@ func (i *iperf3) Run(c *kubernetes.Clientset,
 		}
 		log.Debug(strings.TrimSpace(stdout.String()))
 		return stdout, nil
-		// VM mode
-	} else {
-		sshclient, err := k8s.SSHConnect(perf)
-		if err != nil {
-			return stdout, err
-		}
-		stdout, err := sshclient.Run(fmt.Sprintf("cat %s", file))
-		if err != nil {
-			if closeErr := sshclient.Close(); closeErr != nil {
-				log.Warnf("Error closing SSH client: %v", closeErr)
-			}
-			return *bytes.NewBuffer(stdout), err
-		}
-		log.Debug(strings.TrimSpace(bytes.NewBuffer(stdout).String()))
-		if err := sshclient.Close(); err != nil {
-			log.Warnf("Error closing SSH client: %v", err)
-		}
-		return *bytes.NewBuffer(stdout), nil
 	}
 }
 

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -643,7 +643,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				}
 			}
 			if s.VM {
-				err = launchClientVM(s, clientAcrossRole, &cdpAcross.PodAntiAffinity, &cdpHostAcross.NodeAffinity)
+				err = launchClientVM(s, hostNetClientRole, &cdpAcross.PodAntiAffinity, &cdpHostAcross.NodeAffinity)
 				if err != nil {
 					return err
 				}
@@ -667,7 +667,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				}
 			}
 			if s.VM {
-				err = launchClientVM(s, clientAcrossRole, &cdpAcross.PodAntiAffinity, &cdpHostAcross.NodeAffinity)
+				err = launchClientVM(s, clientAcrossRole, &cdpAcross.PodAntiAffinity, &cdpAcross.NodeAffinity)
 				if err != nil {
 					return err
 				}
@@ -813,7 +813,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				}
 			}
 			if s.VM {
-				err = launchServerVM(s, serverRole, &sdp.PodAntiAffinity, &sdp.NodeAffinity)
+				err = launchServerVM(s, hostNetServerRole, &sdpHost.PodAntiAffinity, &sdpHost.NodeAffinity)
 				if err != nil {
 					return err
 				}
@@ -929,28 +929,28 @@ func ExtractUdnIp(pod corev1.Pod, networkName string) (string, error) {
 
 // launchServerVM will create the ServerVM with the specific node and pod affinity.
 func launchServerVM(perf *config.PerfScenarios, name string, podAff *corev1.PodAntiAffinity, nodeAff *corev1.NodeAffinity) error {
-	_, err := CreateVMServer(perf.KClient, serverRole, serverRole, *podAff, *nodeAff, perf.VMImage, perf.BridgeServerNetwork, perf.Udn, perf.UdnPluginBinding, perf.Cudn,
+	_, err := CreateVMServer(perf.KClient, name, serverRole, *podAff, *nodeAff, perf.VMImage, perf.BridgeServerNetwork, perf.Udn, perf.UdnPluginBinding, perf.Cudn,
 		perf.Sockets, perf.Cores, perf.Threads)
 	if err != nil {
 		return err
 	}
-	err = WaitForVMI(perf.KClient, serverRole)
+	err = WaitForVMI(perf.KClient, name)
 	if err != nil {
 		return err
 	}
 
 	if strings.Contains(name, "host") {
-		perf.VMServerHost, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", serverRole))
+		perf.VMServerHost, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", name))
 		if err != nil {
 			return err
 		}
 	} else {
-		perf.VMServer, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", serverRole))
+		perf.VMServer, err = GetPods(perf.ClientSet, fmt.Sprintf("app=%s", name))
 		if err != nil {
 			return err
 		}
 	}
-	perf.ServerNodeInfo, _ = GetPodNodeInfo(perf.ClientSet, fmt.Sprintf("app=%s", serverRole))
+	perf.ServerNodeInfo, _ = GetPodNodeInfo(perf.ClientSet, fmt.Sprintf("app=%s", name))
 	return nil
 }
 

--- a/pkg/k8s/kubevirt.go
+++ b/pkg/k8s/kubevirt.go
@@ -189,8 +189,7 @@ chpasswd:
     fedora:fedora
   expire: False
 runcmd:
-  - dnf clean all
-  - dnf install -y --nodocs uperf iperf3 git ethtool automake gcc bc lksctp-tools-devel texinfo --enablerepo=*
+  - until dnf install -y --nodocs uperf iperf3 git ethtool automake gcc bc lksctp-tools-devel texinfo --enablerepo=*; do sleep 3; done
   - git clone https://github.com/HewlettPackard/netperf.git
   - cd netperf
   - git reset --hard 3bc455b23f901dae377ca0a558e1e32aa56b31c4
@@ -329,8 +328,7 @@ chpasswd:
     fedora:fedora
   expire: False
 runcmd:
-  - dnf clean all
-  - dnf install -y --nodocs uperf iperf3 git ethtool automake gcc bc lksctp-tools-devel texinfo --enablerepo=*
+  - until dnf install -y --nodocs uperf iperf3 git ethtool automake gcc bc lksctp-tools-devel texinfo --enablerepo=*; do sleep 3; done
   - git clone https://github.com/HewlettPackard/netperf.git
   - cd netperf
   - git reset --hard 3bc455b23f901dae377ca0a558e1e32aa56b31c4

--- a/pkg/k8s/kubevirt.go
+++ b/pkg/k8s/kubevirt.go
@@ -70,7 +70,7 @@ func SSHConnect(conf *config.PerfScenarios) (*goph.Client, error) {
 	if conf.HostNetwork {
 		sshPort = sshPortLocal
 	}
-	log.Debugf("Attempting to connect with : %s@%s on port %s", user, addr, sshPort)
+	log.Debugf("Attempting to connect with : %s@%s", user, addr)
 
 	config := goph.Config{
 		User:     user,

--- a/pkg/k8s/kubevirt.go
+++ b/pkg/k8s/kubevirt.go
@@ -189,6 +189,7 @@ chpasswd:
     fedora:fedora
   expire: False
 runcmd:
+  - export HOME=/home/fedora
   - until dnf install -y --nodocs uperf iperf3 git ethtool automake gcc bc lksctp-tools-devel texinfo --enablerepo=*; do sleep 3; done
   - git clone https://github.com/HewlettPackard/netperf.git
   - cd netperf
@@ -328,6 +329,7 @@ chpasswd:
     fedora:fedora
   expire: False
 runcmd:
+  - export HOME=/home/fedora
   - until dnf install -y --nodocs uperf iperf3 git ethtool automake gcc bc lksctp-tools-devel texinfo --enablerepo=*; do sleep 3; done
   - git clone https://github.com/HewlettPackard/netperf.git
   - cd netperf


### PR DESCRIPTION
## Type of change

- [X] New feature
- [X] Bug fix


## Description

* Enables SVC with both VM and pod flags enabled.
* Fixes errors with hostnet enable when using VMs
* Disables hostnet workloads with VMs workloads (--all mode included)
* Fixes cloud-init zchunk issue

## Related Tickets & Documents

- Related Issue #228
