### PR TITLE
Change default VM podnet binding to masquerade

### DIFF
--- a/pkg/k8s/kubevirt.go
+++ b/pkg/k8s/kubevirt.go
@@ -207,7 +207,7 @@ runcmd:
 		{
 			Name: "default",
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{
-				Bridge: &v1.InterfaceBridge{},
+				Masquerade: &v1.InterfaceMasquerade{},
 			},
 		},
 	}
@@ -348,7 +348,7 @@ runcmd:
 		{
 			Name: "default",
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{
-				Bridge: &v1.InterfaceBridge{},
+				Masquerade: &v1.InterfaceMasquerade{},
 			},
 		},
 	}


### PR DESCRIPTION
## Type of change

- [x] Refactor

## Description
For the default podnet interface, masquerade is the only supported binding type for VM live migration (and most commonly used)

## Related Tickets & Documents

- Related Issue #233 
Resolves the default concern, but adding a bridge binding option may still be useful later for overhead comparisons. 
