### PR TITLE
Add SR-IOV network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For detailed documentation, please refer to the following guides:
 - **Multiple benchmark tools**: Support for netperf, iperf3, uperf and ib_write_bw
 - **Flexible test scenarios**: Pod-to-pod, host networking, cross-AZ testing
 - **Virtual Machine support**: Test with KubeVirt VMs
-- **Advanced networking**: User Defined Networks (UDN) and bridge interfaces
+- **Advanced networking**: User Defined Networks (UDN), bridge interfaces, and SR-IOV
 - **Pass/fail validation**: Automated performance regression detection
 - **Result archiving**: CSV export and OpenSearch integration
 - **Prometheus integration**: System metrics collection during tests

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -59,6 +59,7 @@ var (
 	bridge           string
 	bridgeNetwork    string
 	bridgeNamespace  string
+	sriov            string
 	promURL          string
 	id               string
 	searchURL        string
@@ -120,6 +121,18 @@ var rootCmd = &cobra.Command{
 		if ibWriteBwEnabled && bridge != "" {
 			log.Fatalf("😭 ib_write_bw driver cannot be used with --bridge flag")
 		}
+		if sriov != "" && bridge != "" {
+			log.Fatalf("😭 --sriov and --bridge are mutually exclusive")
+		}
+		if sriov != "" && ibWriteBwEnabled {
+			log.Fatalf("😭 --sriov and --ib-write-bw are mutually exclusive")
+		}
+		if sriov != "" && (udnl2 || udnl3 || cudn != "") {
+			log.Fatalf("😭 --sriov cannot be used with UDN flags (--udnl2, --udnl3, --cudn)")
+		}
+		if sriov != "" && hostNetOnly {
+			log.Fatalf("😭 --sriov cannot be used with --hostNet")
+		}
 
 		// If a specific driver is explicitly requested, disable the default netperf driver
 		if (iperf3 || uperf || ibWriteBwEnabled) && !cmd.Flags().Changed("netperf") {
@@ -174,6 +187,7 @@ var rootCmd = &cobra.Command{
 			ClientSet:       client,
 			BridgeNetwork:   bridge,
 			BridgeNamespace: bridgeNamespace,
+			SriovNetwork:    sriov,
 			Cudn:            cudn != "",
 			IbWriteBwParams: ibWriteBw,
 			Sockets:         sockets,
@@ -293,6 +307,33 @@ var rootCmd = &cobra.Command{
 			err = k8s.ValidateBridgeNetwork(client, dynClient, bridge, bridgeNamespace)
 			if err != nil {
 				log.Fatalf("Bridge network validation failed: %v", err)
+			}
+		}
+
+		// Deploy SR-IOV resources if requested
+		if sriov != "" {
+			if s.DClient == nil {
+				dynClient, err := dynamic.NewForConfig(rconfig)
+				if err != nil {
+					log.Fatalf("Failed to create dynamic client for SR-IOV: %v", err)
+				}
+				s.DClient = dynClient
+			}
+			err = k8s.DeploySriovOperatorConfig(s.DClient)
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = k8s.DeploySriovPolicy(s.DClient, sriov)
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = k8s.DeploySriovNetwork(s.DClient, sriov)
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = k8s.WaitForSriovNad(s.DClient)
+			if err != nil {
+				log.Fatal(err)
 			}
 		}
 
@@ -537,6 +578,16 @@ func cleanup(client *kubernetes.Clientset, rconfig *rest.Config) {
 			log.Error(err)
 		}
 	}
+	if sriov != "" {
+		dynClient, err := dynamic.NewForConfig(rconfig)
+		if err != nil {
+			log.Error(err)
+		}
+		err = k8s.DestroySriovResources(dynClient)
+		if err != nil {
+			log.Error(err)
+		}
+	}
 	err := k8s.DestroyNamespace(client)
 	if err != nil {
 		log.Error(err)
@@ -637,6 +688,13 @@ func executeWorkload(nc config.Config,
 			log.Fatal(err)
 		}
 		npr.UdnInfo = "Cudn -" + cudn
+	} else if s.SriovNetwork != "" {
+		serverIP, err = k8s.ExtractSriovIp(s.Server.Items[0])
+		if err != nil {
+			log.Fatalf("Failed to extract SR-IOV IP: %v", err)
+		}
+		log.Debugf("Using SR-IOV network IP: %s", serverIP)
+		npr.SriovInfo = fmt.Sprintf("sriov/%s", s.SriovNetwork)
 	} else if s.BridgeNetwork != "" {
 		// For regular pods, extract bridge IP from network status
 		serverIP, err = k8s.ExtractBridgeIp(s.Server.Items[0], s.BridgeNetwork, s.BridgeNamespace)
@@ -769,6 +827,7 @@ func main() {
 	rootCmd.Flags().StringVar(&bridge, "bridge", "", "Name of the NetworkAttachmentDefinition to be used for bridge interface")
 	rootCmd.Flags().StringVar(&bridgeNamespace, "bridgeNamespace", "default", "Namespace of the NetworkAttachmentDefinition for bridge interface (default default)")
 	rootCmd.Flags().StringVar(&bridgeNetwork, "bridgeNetwork", "bridgeNetwork.json", "Json file for the VM network defined by the bridge interface - bridge should be enabled (default bridgeNetwork.json)")
+	rootCmd.Flags().StringVar(&sriov, "sriov", "", "SR-IOV PF interface name (e.g., ens1f0). Creates SriovNetworkNodePolicy and SriovNetwork CRs. Requires SR-IOV operator.")
 	rootCmd.Flags().StringVar(&promURL, "prom", "", "Prometheus URL")
 	rootCmd.Flags().StringVar(&id, "uuid", "", "User provided UUID")
 	rootCmd.Flags().StringVar(&searchURL, "search", "", "OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port")

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -134,6 +134,9 @@ var rootCmd = &cobra.Command{
 		if sriov != "" && hostNetOnly {
 			log.Fatalf("😭 --sriov cannot be used with --hostNet")
 		}
+		if sriov != "" && vm && pod {
+			log.Fatalf("😭 --sriov with --vm requires --pod=false. Pod SR-IOV uses deviceType netdevice while VM SR-IOV uses vfio-pci — they cannot share the same VFs.")
+		}
 
 		// If a specific driver is explicitly requested, disable the default netperf driver
 		if (iperf3 || uperf || ibWriteBwEnabled) && !cmd.Flags().Changed("netperf") {
@@ -324,7 +327,7 @@ var rootCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			err = k8s.DeploySriovPolicy(s.DClient, sriov, sriovNodeSelector)
+			err = k8s.DeploySriovPolicy(s.DClient, sriov, sriovNodeSelector, vm)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -690,7 +693,11 @@ func executeWorkload(nc config.Config,
 		}
 		npr.UdnInfo = "Cudn -" + cudn
 	} else if s.SriovNetwork != "" {
-		serverIP, err = k8s.ExtractSriovIp(s.Server.Items[0])
+		if virt {
+			serverIP, err = k8s.ExtractSriovIp(s.VMServer.Items[0])
+		} else {
+			serverIP, err = k8s.ExtractSriovIp(s.Server.Items[0])
+		}
 		if err != nil {
 			log.Fatalf("Failed to extract SR-IOV IP: %v", err)
 		}

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -60,6 +60,7 @@ var (
 	bridgeNetwork    string
 	bridgeNamespace  string
 	sriov            string
+	sriovNodeSelector string
 	promURL          string
 	id               string
 	searchURL        string
@@ -319,11 +320,11 @@ var rootCmd = &cobra.Command{
 				}
 				s.DClient = dynClient
 			}
-			err = k8s.DeploySriovOperatorConfig(s.DClient)
+			err = k8s.DeploySriovOperatorConfig(s.DClient, sriovNodeSelector)
 			if err != nil {
 				log.Fatal(err)
 			}
-			err = k8s.DeploySriovPolicy(s.DClient, sriov)
+			err = k8s.DeploySriovPolicy(s.DClient, sriov, sriovNodeSelector)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -828,6 +829,7 @@ func main() {
 	rootCmd.Flags().StringVar(&bridgeNamespace, "bridgeNamespace", "default", "Namespace of the NetworkAttachmentDefinition for bridge interface (default default)")
 	rootCmd.Flags().StringVar(&bridgeNetwork, "bridgeNetwork", "bridgeNetwork.json", "Json file for the VM network defined by the bridge interface - bridge should be enabled (default bridgeNetwork.json)")
 	rootCmd.Flags().StringVar(&sriov, "sriov", "", "SR-IOV PF interface name (e.g., ens1f0). Creates SriovNetworkNodePolicy and SriovNetwork CRs. Requires SR-IOV operator.")
+	rootCmd.Flags().StringVar(&sriovNodeSelector, "sriov-node-selector", "worker", "Node role label for SR-IOV node selector (default worker)")
 	rootCmd.Flags().StringVar(&promURL, "prom", "", "Prometheus URL")
 	rootCmd.Flags().StringVar(&id, "uuid", "", "User provided UUID")
 	rootCmd.Flags().StringVar(&searchURL, "search", "", "OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port")

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -62,6 +62,7 @@ $ k8s-netperf --cudn layer3 --vm
 ## SR-IOV Network Testing
 To run k8s-netperf over SR-IOV Virtual Functions, the SR-IOV Network Operator must be installed on the cluster. k8s-netperf will automatically create the required `SriovNetworkNodePolicy` and `SriovNetwork` CRs, and clean them up after the test.
 
+### Pod SR-IOV
 Pass the PF (Physical Function) interface name to the `--sriov` flag:
 ```bash
 k8s-netperf --sriov ens2f0np0
@@ -76,6 +77,21 @@ By default, the SR-IOV policy targets nodes with the `node-role.kubernetes.io/wo
 ```bash
 k8s-netperf --sriov ens2f0np0 --sriov-node-selector cnf-worker
 ```
+
+### VM SR-IOV
+SR-IOV is also supported with KubeVirt VMs. When `--vm` is used with `--sriov`, VFs are created with `deviceType: vfio-pci` and passed through to the guest via PCI passthrough. The IP address assigned by whereabouts to the virt-launcher pod is configured inside the guest VM using `nmcli` over virtctl SSH.
+
+```bash
+k8s-netperf --sriov ens1f0 --vm --use-virtctl --pod=false
+```
+
+Requirements for VM SR-IOV:
+- OpenShift CNV (KubeVirt) must be deployed
+- The PF must use a driver supported by the VM containerdisk (e.g. Intel `ice`/`iavf` drivers are included in Fedora 39; Mellanox `mlx5_core` is not)
+- SSH keys must be present in `~/.ssh/id_rsa.pub`
+- `virtctl` is recommended (`--use-virtctl`) for SSH access into the guest VMs
+
+> Note: Pod and VM SR-IOV tests cannot run in the same invocation because pods require `deviceType: netdevice` while VMs require `deviceType: vfio-pci`. Run them separately with `--pod=false` for VM-only or without `--vm` for pod-only.
 
 > Note: `--sriov` is mutually exclusive with `--bridge`, `--ib-write-bw`, `--hostNet`, and UDN flags (`--udnl2`, `--udnl3`, `--cudn`).
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -59,6 +59,26 @@ $ k8s-netperf --cudn layer2 --vm
 # or
 $ k8s-netperf --cudn layer3 --vm
 ```
+## SR-IOV Network Testing
+To run k8s-netperf over SR-IOV Virtual Functions, the SR-IOV Network Operator must be installed on the cluster. k8s-netperf will automatically create the required `SriovNetworkNodePolicy` and `SriovNetwork` CRs, and clean them up after the test.
+
+Pass the PF (Physical Function) interface name to the `--sriov` flag:
+```bash
+k8s-netperf --sriov ens2f0np0
+```
+
+On a single-node cluster:
+```bash
+k8s-netperf --sriov ens2f0np0 --local
+```
+
+By default, the SR-IOV policy targets nodes with the `node-role.kubernetes.io/worker` label. If SR-IOV NICs are only available on nodes with a different role label, use `--sriov-node-selector`:
+```bash
+k8s-netperf --sriov ens2f0np0 --sriov-node-selector cnf-worker
+```
+
+> Note: `--sriov` is mutually exclusive with `--bridge`, `--ib-write-bw`, `--hostNet`, and UDN flags (`--udnl2`, `--udnl3`, `--cudn`).
+
 ## Using a Linux Bridge Interface
 When using `--bridge`, a NetworkAttachmentDefinition defining a bridge interface is attached to the VMs and is used for the test. It requires the name of the bridge as it is defined in the NetworkNodeConfigurationPolicy, NMstate operator is required.
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -58,6 +58,7 @@ type Doc struct {
 	ExternalServer    bool             `json:"externalServer"`
 	UdnInfo           string           `json:"udnInfo"`
 	BridgeInfo        string           `json:"bridgeInfo"`
+	SriovInfo         string           `json:"sriovInfo"`
 }
 
 // Connect returns a client connected to the desired cluster.
@@ -132,6 +133,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 			ServerNodeInfo:    r.ServerNodeInfo,
 			UdnInfo:           r.UdnInfo,
 			BridgeInfo:        r.BridgeInfo,
+			SriovInfo:         r.SriovInfo,
 		}
 		UDPLossPercent, e := result.Average(r.LossSummary)
 		if e != nil {
@@ -178,6 +180,7 @@ func commonCsvHeaderFields() []string {
 		"External Server",
 		"UDN Info",
 		"Bridge Info",
+		"SR-IOV Info",
 		"Duration",
 		"Parallelism",
 		"# of Samples",
@@ -204,6 +207,7 @@ func commonCsvDataFields(row result.Data) []string {
 		fmt.Sprint(row.ExternalServer),
 		fmt.Sprint(row.UdnInfo),
 		fmt.Sprint(row.BridgeInfo),
+		fmt.Sprint(row.SriovInfo),
 		strconv.Itoa(row.Duration),
 		strconv.Itoa(row.Parallelism),
 		strconv.Itoa(row.Samples),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,7 @@ type PerfScenarios struct {
 	BridgeNamespace     string
 	BridgeServerNetwork string
 	BridgeClientNetwork string
+	SriovNetwork        string
 	IbWriteBwParams     string
 	Sockets             uint32
 	Cores               uint32

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -386,7 +386,7 @@ func DeployNADBridge(dyn *dynamic.DynamicClient, bridgeName string) error {
 }
 
 // DeploySriovOperatorConfig applies the SriovOperatorConfig with disableDrain to avoid node drain/reboot
-func DeploySriovOperatorConfig(dyn *dynamic.DynamicClient) error {
+func DeploySriovOperatorConfig(dyn *dynamic.DynamicClient, nodeRole string) error {
 	log.Infof("Applying SriovOperatorConfig with disableDrain: true")
 	gvr := schema.GroupVersionResource{
 		Group:    "sriovnetwork.openshift.io",
@@ -402,7 +402,7 @@ func DeploySriovOperatorConfig(dyn *dynamic.DynamicClient) error {
 		spec = make(map[string]interface{})
 	}
 	spec["configDaemonNodeSelector"] = map[string]interface{}{
-		"node-role.kubernetes.io/worker": "",
+		"node-role.kubernetes.io/" + nodeRole: "",
 	}
 	spec["disableDrain"] = true
 	existing.Object["spec"] = spec
@@ -414,7 +414,7 @@ func DeploySriovOperatorConfig(dyn *dynamic.DynamicClient) error {
 }
 
 // DeploySriovPolicy creates a SriovNetworkNodePolicy CR to carve VFs from a PF
-func DeploySriovPolicy(dyn *dynamic.DynamicClient, pfName string) error {
+func DeploySriovPolicy(dyn *dynamic.DynamicClient, pfName string, nodeRole string) error {
 	log.Infof("Deploying SriovNetworkNodePolicy for PF: %s", pfName)
 	policy := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -432,7 +432,7 @@ func DeploySriovPolicy(dyn *dynamic.DynamicClient, pfName string) error {
 					"pfNames": []string{pfName},
 				},
 				"nodeSelector": map[string]interface{}{
-					"node-role.kubernetes.io/worker": "",
+					"node-role.kubernetes.io/" + nodeRole: "",
 				},
 			},
 		},

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -414,8 +414,12 @@ func DeploySriovOperatorConfig(dyn *dynamic.DynamicClient, nodeRole string) erro
 }
 
 // DeploySriovPolicy creates a SriovNetworkNodePolicy CR to carve VFs from a PF
-func DeploySriovPolicy(dyn *dynamic.DynamicClient, pfName string, nodeRole string) error {
-	log.Infof("Deploying SriovNetworkNodePolicy for PF: %s", pfName)
+func DeploySriovPolicy(dyn *dynamic.DynamicClient, pfName string, nodeRole string, vm bool) error {
+	deviceType := "netdevice"
+	if vm {
+		deviceType = "vfio-pci"
+	}
+	log.Infof("Deploying SriovNetworkNodePolicy for PF: %s (deviceType: %s)", pfName, deviceType)
 	policy := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "sriovnetwork.openshift.io/v1",
@@ -426,7 +430,7 @@ func DeploySriovPolicy(dyn *dynamic.DynamicClient, pfName string, nodeRole strin
 			},
 			"spec": map[string]interface{}{
 				"resourceName": pfName,
-				"deviceType":   "netdevice",
+				"deviceType":   deviceType,
 				"numVfs":       2,
 				"nicSelector": map[string]interface{}{
 					"pfNames": []string{pfName},
@@ -1189,7 +1193,7 @@ func ExtractUdnIp(pod corev1.Pod, networkName string) (string, error) {
 // launchServerVM will create the ServerVM with the specific node and pod affinity.
 func launchServerVM(perf *config.PerfScenarios, name string, podAff *corev1.PodAntiAffinity, nodeAff *corev1.NodeAffinity) error {
 	_, err := CreateVMServer(perf.KClient, name, name, *podAff, *nodeAff, perf.VMImage, perf.BridgeServerNetwork, perf.Udn, perf.UdnPluginBinding, perf.Cudn,
-		perf.Sockets, perf.Cores, perf.Threads)
+		perf.SriovNetwork, perf.Sockets, perf.Cores, perf.Threads)
 	if err != nil {
 		return err
 	}
@@ -1204,13 +1208,20 @@ func launchServerVM(perf *config.PerfScenarios, name string, podAff *corev1.PodA
 	}
 
 	perf.ServerNodeInfo, _ = GetPodNodeInfo(perf.ClientSet, fmt.Sprintf("app=%s", name))
+
+	if perf.SriovNetwork != "" && len(perf.VMServer.Items) > 0 {
+		err = ConfigureVMSriovIP(name, perf.VMServer.Items[0])
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 // launchClientVM will create the ClientVM with the specific node and pod affinity.
 func launchClientVM(perf *config.PerfScenarios, name string, podAff *corev1.PodAntiAffinity, nodeAff *corev1.NodeAffinity) error {
 	host, err := CreateVMClient(perf.KClient, perf.ClientSet, perf.DClient, name, podAff, nodeAff, perf.VMImage, perf.BridgeClientNetwork, perf.Udn, perf.UdnPluginBinding, perf.Cudn,
-		perf.Sockets, perf.Cores, perf.Threads)
+		perf.SriovNetwork, perf.Sockets, perf.Cores, perf.Threads)
 	if err != nil {
 		return err
 	}
@@ -1225,6 +1236,13 @@ func launchClientVM(perf *config.PerfScenarios, name string, podAff *corev1.PodA
 		return err
 	}
 	perf.ClientNodeInfo, _ = GetPodNodeInfo(perf.ClientSet, fmt.Sprintf("app=%s", name))
+
+	if perf.SriovNetwork != "" && len(perf.VMClientAcross.Items) > 0 {
+		err = ConfigureVMSriovIP(name, perf.VMClientAcross.Items[0])
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/config"
 	log "github.com/cloud-bulldozer/k8s-netperf/pkg/logging"
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -40,6 +42,7 @@ type DeploymentParams struct {
 	NodeAffinity       corev1.NodeAffinity
 	Port               int
 	NetworkAnnotations map[string]string
+	ResourceRequests   corev1.ResourceList
 }
 
 // ServiceParams describes the service specific details
@@ -98,6 +101,9 @@ const hostNetClientRole = "host-client"
 const k8sNetperfImage = "quay.io/cloud-bulldozer/k8s-netperf:latest"
 const UdnName = "udn-primary-netperf"
 const CudnName = "cudn-secondary-netperf"
+const SriovNadName = "sriov-netperf"
+const SriovPolicyName = "sriov-netperf-policy"
+const sriovOperatorNamespace = "openshift-sriov-network-operator"
 
 // ValidateBridgeNetwork validates that the specified bridge namespace and NetworkAttachmentDefinition exist
 func ValidateBridgeNetwork(client *kubernetes.Clientset, dyn dynamic.Interface, bridgeNetwork, bridgeNamespace string) error {
@@ -145,6 +151,14 @@ func buildCUdnNetworkAnnotations(cudn string) map[string]string {
 		annotations["k8s.v1.cni.cncf.io/networks"] = namespace + "/" + cudn
 		log.Infof("🌉 Configuring CUdn network: %s", namespace+"/"+cudn)
 	}
+	return annotations
+}
+
+// buildSriovNetworkAnnotations creates the network annotations for Multus CNI SR-IOV networks
+func buildSriovNetworkAnnotations() map[string]string {
+	annotations := make(map[string]string)
+	annotations["k8s.v1.cni.cncf.io/networks"] = namespace + "/" + SriovNadName
+	log.Infof("🌉 Configuring SR-IOV network: %s", namespace+"/"+SriovNadName)
 	return annotations
 }
 
@@ -371,11 +385,162 @@ func DeployNADBridge(dyn *dynamic.DynamicClient, bridgeName string) error {
 	return nil
 }
 
+// DeploySriovOperatorConfig applies the SriovOperatorConfig with disableDrain to avoid node drain/reboot
+func DeploySriovOperatorConfig(dyn *dynamic.DynamicClient) error {
+	log.Infof("Applying SriovOperatorConfig with disableDrain: true")
+	gvr := schema.GroupVersionResource{
+		Group:    "sriovnetwork.openshift.io",
+		Version:  "v1",
+		Resource: "sriovoperatorconfigs",
+	}
+	existing, err := dyn.Resource(gvr).Namespace(sriovOperatorNamespace).Get(context.TODO(), "default", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to get SriovOperatorConfig: %v", err)
+	}
+	spec, _ := existing.Object["spec"].(map[string]interface{})
+	if spec == nil {
+		spec = make(map[string]interface{})
+	}
+	spec["configDaemonNodeSelector"] = map[string]interface{}{
+		"node-role.kubernetes.io/worker": "",
+	}
+	spec["disableDrain"] = true
+	existing.Object["spec"] = spec
+	_, err = dyn.Resource(gvr).Namespace(sriovOperatorNamespace).Update(context.TODO(), existing, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to update SriovOperatorConfig: %v", err)
+	}
+	return nil
+}
+
+// DeploySriovPolicy creates a SriovNetworkNodePolicy CR to carve VFs from a PF
+func DeploySriovPolicy(dyn *dynamic.DynamicClient, pfName string) error {
+	log.Infof("Deploying SriovNetworkNodePolicy for PF: %s", pfName)
+	policy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "sriovnetwork.openshift.io/v1",
+			"kind":       "SriovNetworkNodePolicy",
+			"metadata": map[string]interface{}{
+				"name":      SriovPolicyName,
+				"namespace": sriovOperatorNamespace,
+			},
+			"spec": map[string]interface{}{
+				"resourceName": pfName,
+				"deviceType":   "netdevice",
+				"numVfs":       2,
+				"nicSelector": map[string]interface{}{
+					"pfNames": []string{pfName},
+				},
+				"nodeSelector": map[string]interface{}{
+					"node-role.kubernetes.io/worker": "",
+				},
+			},
+		},
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    "sriovnetwork.openshift.io",
+		Version:  "v1",
+		Resource: "sriovnetworknodepolicies",
+	}
+	_, err := dyn.Resource(gvr).Namespace(sriovOperatorNamespace).Create(context.TODO(), policy, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to create SriovNetworkNodePolicy: %v", err)
+	}
+	return nil
+}
+
+// DeploySriovNetwork creates a SriovNetwork CR which auto-generates a NAD in the netperf namespace
+func DeploySriovNetwork(dyn *dynamic.DynamicClient, resourceName string) error {
+	log.Infof("Deploying SriovNetwork with resourceName: %s", resourceName)
+	sriovNet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "sriovnetwork.openshift.io/v1",
+			"kind":       "SriovNetwork",
+			"metadata": map[string]interface{}{
+				"name":      SriovNadName,
+				"namespace": sriovOperatorNamespace,
+			},
+			"spec": map[string]interface{}{
+				"networkNamespace": namespace,
+				"resourceName":    resourceName,
+				"ipam":            `{"type": "whereabouts", "range": "192.168.100.0/24"}`,
+			},
+		},
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    "sriovnetwork.openshift.io",
+		Version:  "v1",
+		Resource: "sriovnetworks",
+	}
+	_, err := dyn.Resource(gvr).Namespace(sriovOperatorNamespace).Create(context.TODO(), sriovNet, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to create SriovNetwork: %v", err)
+	}
+	return nil
+}
+
+// WaitForSriovNad polls for the SR-IOV NAD to be created in the netperf namespace
+func WaitForSriovNad(dyn *dynamic.DynamicClient) error {
+	log.Infof("Waiting for SR-IOV NetworkAttachmentDefinition %s in namespace %s...", SriovNadName, namespace)
+	gvr := schema.GroupVersionResource{
+		Group:    "k8s.cni.cncf.io",
+		Version:  "v1",
+		Resource: "network-attachment-definitions",
+	}
+	// Poll every 5 seconds for up to 120 seconds
+	for i := 0; i < 24; i++ {
+		_, err := dyn.Resource(gvr).Namespace(namespace).Get(context.TODO(), SriovNadName, metav1.GetOptions{})
+		if err == nil {
+			log.Infof("SR-IOV NetworkAttachmentDefinition %s is ready", SriovNadName)
+			return nil
+		}
+		log.Debugf("NAD not yet available, retrying in 5s... (%d/24)", i+1)
+		time.Sleep(5 * time.Second)
+	}
+	return fmt.Errorf("timed out waiting for SR-IOV NAD %s in namespace %s", SriovNadName, namespace)
+}
+
+// DestroySriovResources cleans up the SriovNetwork and SriovNetworkNodePolicy CRs
+func DestroySriovResources(dyn *dynamic.DynamicClient) error {
+	log.Info("Cleaning up SR-IOV resources")
+	deletePolicy := metav1.DeletePropagationForeground
+	opts := metav1.DeleteOptions{PropagationPolicy: &deletePolicy}
+
+	gvrNet := schema.GroupVersionResource{
+		Group:    "sriovnetwork.openshift.io",
+		Version:  "v1",
+		Resource: "sriovnetworks",
+	}
+	err := dyn.Resource(gvrNet).Namespace(sriovOperatorNamespace).Delete(context.TODO(), SriovNadName, opts)
+	if err != nil {
+		log.Warnf("Failed to delete SriovNetwork: %v", err)
+	}
+
+	gvrPolicy := schema.GroupVersionResource{
+		Group:    "sriovnetwork.openshift.io",
+		Version:  "v1",
+		Resource: "sriovnetworknodepolicies",
+	}
+	err = dyn.Resource(gvrPolicy).Namespace(sriovOperatorNamespace).Delete(context.TODO(), SriovPolicyName, opts)
+	if err != nil {
+		log.Warnf("Failed to delete SriovNetworkNodePolicy: %v", err)
+	}
+	return nil
+}
+
 // BuildSUT Build the k8s env to run network performance tests
 func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	var netperfDataPorts []int32
 	var netperfVmDataPorts []int32
 	var err error
+
+	// Build SR-IOV resource requests if needed
+	var sriovResources corev1.ResourceList
+	if s.SriovNetwork != "" {
+		sriovResources = corev1.ResourceList{
+			corev1.ResourceName("openshift.io/" + s.SriovNetwork): resource.MustParse("1"),
+		}
+	}
 
 	// Schedule pods to nodes with role worker=, but not nodes with infra= and workload=
 	workerNodeSelectorExpression := &corev1.NodeSelector{
@@ -397,6 +562,8 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			networkAnnotations = buildBridgeNetworkAnnotations(s.BridgeNetwork, s.BridgeNamespace)
 		} else if s.Cudn {
 			networkAnnotations = buildCUdnNetworkAnnotations(CudnName)
+		} else if s.SriovNetwork != "" {
+			networkAnnotations = buildSriovNetworkAnnotations()
 		}
 		cdp := DeploymentParams{
 			Name:               "client",
@@ -407,6 +574,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 			Port:               NetperfServerCtlPort,
 			NetworkAnnotations: networkAnnotations,
+			ResourceRequests:   sriovResources,
 			Privileged:         s.Privileged,
 		}
 
@@ -481,6 +649,8 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			networkAnnotations = buildBridgeNetworkAnnotations(s.BridgeNetwork, s.BridgeNamespace)
 		} else if s.Cudn {
 			networkAnnotations = buildCUdnNetworkAnnotations(CudnName)
+		} else if s.SriovNetwork != "" {
+			networkAnnotations = buildSriovNetworkAnnotations()
 		}
 		cdp := DeploymentParams{
 			Name:               "client",
@@ -492,6 +662,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 			Port:               NetperfServerCtlPort,
 			NetworkAnnotations: networkAnnotations,
+			ResourceRequests:   sriovResources,
 			Privileged:         s.Privileged,
 		}
 		if z != "" && numNodes > 1 {
@@ -633,6 +804,8 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		networkAnnotations = buildBridgeNetworkAnnotations(s.BridgeNetwork, s.BridgeNamespace)
 	} else if s.Cudn {
 		networkAnnotations = buildCUdnNetworkAnnotations(CudnName)
+	} else if s.SriovNetwork != "" {
+		networkAnnotations = buildSriovNetworkAnnotations()
 	}
 	cdpAcross := DeploymentParams{
 		Name:               "client-across",
@@ -643,6 +816,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 		Port:               NetperfServerCtlPort,
 		NetworkAnnotations: networkAnnotations,
+		ResourceRequests:   sriovResources,
 		Privileged:         s.Privileged,
 	}
 	cdpAcross.PodAntiAffinity = corev1.PodAntiAffinity{
@@ -786,6 +960,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		Commands:           dpCommands,
 		Port:               NetperfServerCtlPort,
 		NetworkAnnotations: networkAnnotations,
+		ResourceRequests:   sriovResources,
 		Privileged:         s.Privileged,
 	}
 	if s.NodeLocal {
@@ -941,6 +1116,40 @@ func ExtractBridgeIp(pod corev1.Pod, bridgeNetworkName, bridgeNamespace string) 
 	}
 
 	return "", fmt.Errorf("bridge network IP not found for %s on pod %s", expectedNetworkName, pod.Name)
+}
+
+// ExtractSriovIp extracts the SR-IOV network IP address from pod network status annotation
+func ExtractSriovIp(pod corev1.Pod) (string, error) {
+	networkStatusJson := pod.Annotations["k8s.v1.cni.cncf.io/network-status"]
+	if networkStatusJson == "" {
+		return "", fmt.Errorf("no network status annotation found on pod %s", pod.Name)
+	}
+
+	var networkStatuses []struct {
+		Name      string   `json:"name"`
+		Interface string   `json:"interface"`
+		IPs       []string `json:"ips"`
+		Default   bool     `json:"default,omitempty"`
+	}
+
+	err := json.Unmarshal([]byte(networkStatusJson), &networkStatuses)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling network status: %v", err)
+	}
+
+	expectedNetworkName := fmt.Sprintf("%s/%s", namespace, SriovNadName)
+	for _, netStatus := range networkStatuses {
+		if netStatus.Name == expectedNetworkName && len(netStatus.IPs) > 0 {
+			for _, ip := range netStatus.IPs {
+				if strings.Contains(ip, ".") {
+					log.Debugf("Pod %s SR-IOV network IP: %s", pod.Name, ip)
+					return ip, nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("SR-IOV network IP not found for %s on pod %s", expectedNetworkName, pod.Name)
 }
 
 // Extract the UDN Ip address of the server (or the client) from the annotations - Support only ipv4
@@ -1178,6 +1387,14 @@ func CreateDeployment(dp DeploymentParams, client *kubernetes.Clientset) (*appsv
 		if dp.Privileged {
 			container.SecurityContext = &corev1.SecurityContext{
 				Privileged: ptr.To(true),
+			}
+		}
+
+		// Add resource requests (e.g., SR-IOV VFs)
+		if len(dp.ResourceRequests) > 0 {
+			container.Resources = corev1.ResourceRequirements{
+				Requests: dp.ResourceRequests,
+				Limits:   dp.ResourceRequests, // extended resources require limits == requests
 			}
 		}
 

--- a/pkg/k8s/kubevirt.go
+++ b/pkg/k8s/kubevirt.go
@@ -162,7 +162,7 @@ func exposeService(client *kubernetes.Clientset, dynamicClient *dynamic.DynamicC
 // CreateVMClient takes in the affinity rules and deploys the VMI
 func CreateVMClient(kclient *kubevirtv1.KubevirtV1Client, client *kubernetes.Clientset,
 	dyn *dynamic.DynamicClient, name string, podAff *corev1.PodAntiAffinity, nodeAff *corev1.NodeAffinity, vmimage string, bridgeNetwork string, udn bool, udnPluginBinding string,
-	cudn bool, sockets uint32, cores uint32, threads uint32) (string, error) {
+	cudn bool, sriovNetwork string, sockets uint32, cores uint32, threads uint32) (string, error) {
 	label := map[string]string{
 		"app":  name,
 		"role": name,
@@ -181,6 +181,7 @@ users:
   - name: fedora
     groups: sudo
     shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
     ssh_deletekeys: false
     ssh_authorized_keys:
       - %s
@@ -195,9 +196,9 @@ runcmd:
   - cd netperf
   - git reset --hard 3bc455b23f901dae377ca0a558e1e32aa56b31c4
   - curl -o netperf.diff https://raw.githubusercontent.com/cloud-bulldozer/k8s-netperf/main/containers/netperf.diff
-  - git apply netperf.diff 
-  - ./autogen.sh 
-  - ./configure --enable-sctp=yes --enable-demo=yes 
+  - git apply netperf.diff
+  - ./autogen.sh
+  - ./configure --enable-sctp=yes --enable-demo=yes
   - make && make install
   - cd
   - curl -o /usr/bin/super-netperf https://raw.githubusercontent.com/cloud-bulldozer/k8s-netperf/main/containers/super-netperf
@@ -279,8 +280,23 @@ ethernets:
 ethernets:
   eth1:
     dhcp4: true`
+	} else if sriovNetwork != "" {
+		interfaces = append(interfaces, v1.Interface{
+			Name: "sriov-netperf",
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{
+				SRIOV: &v1.InterfaceSRIOV{},
+			},
+		})
+		networks = append(networks, v1.Network{
+			Name: "sriov-netperf",
+			NetworkSource: v1.NetworkSource{
+				Multus: &v1.MultusNetwork{
+					NetworkName: namespace + "/" + SriovNadName,
+				},
+			},
+		})
 	}
-	_, err = CreateVMI(kclient, name, label, b64.StdEncoding.EncodeToString([]byte(data)), *podAff, *nodeAff, vmimage, interfaces, networks, b64.StdEncoding.EncodeToString([]byte(netData)), sockets, cores, threads)
+	_, err = CreateVMI(kclient, name, label, b64.StdEncoding.EncodeToString([]byte(data)), *podAff, *nodeAff, vmimage, interfaces, networks, b64.StdEncoding.EncodeToString([]byte(netData)), sriovNetwork, sockets, cores, threads)
 	if err != nil {
 		return "", err
 	}
@@ -302,7 +318,7 @@ ethernets:
 // CreateVMServer will take the pod and node affinity and deploy the VMI
 func CreateVMServer(client *kubevirtv1.KubevirtV1Client, name string, role string, podAff corev1.PodAntiAffinity,
 	nodeAff corev1.NodeAffinity, vmimage string, bridgeNetwork string, udn bool, udnPluginBinding string, cudn bool,
-	sockets uint32, cores uint32, threads uint32) (*v1.VirtualMachineInstance, error) {
+	sriovNetwork string, sockets uint32, cores uint32, threads uint32) (*v1.VirtualMachineInstance, error) {
 	label := map[string]string{
 		"app":  name,
 		"role": role,
@@ -322,6 +338,7 @@ users:
     ssh_deletekeys: false
     groups: sudo
     shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
     ssh_authorized_keys:
       - %s
 chpasswd:
@@ -420,16 +437,38 @@ ethernets:
 ethernets:
   eth1:
     dhcp4: true`
+	} else if sriovNetwork != "" {
+		interfaces = append(interfaces, v1.Interface{
+			Name: "sriov-netperf",
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{
+				SRIOV: &v1.InterfaceSRIOV{},
+			},
+		})
+		networks = append(networks, v1.Network{
+			Name: "sriov-netperf",
+			NetworkSource: v1.NetworkSource{
+				Multus: &v1.MultusNetwork{
+					NetworkName: namespace + "/" + SriovNadName,
+				},
+			},
+		})
 	}
-	return CreateVMI(client, name, label, b64.StdEncoding.EncodeToString([]byte(data)), podAff, nodeAff, vmimage, interfaces, networks, b64.StdEncoding.EncodeToString([]byte(netData)), sockets, cores, threads)
+	return CreateVMI(client, name, label, b64.StdEncoding.EncodeToString([]byte(data)), podAff, nodeAff, vmimage, interfaces, networks, b64.StdEncoding.EncodeToString([]byte(netData)), sriovNetwork, sockets, cores, threads)
 }
 
 // CreateVMI creates the desired Virtual Machine instance with the cloud-init config with affinity.
 func CreateVMI(client *kubevirtv1.KubevirtV1Client, name string, label map[string]string, b64data string, podAff corev1.PodAntiAffinity,
 	nodeAff corev1.NodeAffinity, vmimage string, interfaces []v1.Interface, networks []v1.Network, netDatab64 string,
-	sockets uint32, cores uint32, threads uint32) (*v1.VirtualMachineInstance, error) {
+	sriovNetwork string, sockets uint32, cores uint32, threads uint32) (*v1.VirtualMachineInstance, error) {
 	delSeconds := int64(0)
 	mutliQ := true
+	resourceRequests := corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("4096Mi"),
+		corev1.ResourceCPU:    resource.MustParse("500m"),
+	}
+	if sriovNetwork != "" {
+		resourceRequests[corev1.ResourceName("openshift.io/"+sriovNetwork)] = resource.MustParse("1")
+	}
 	vmi, err := client.VirtualMachineInstances(namespace).Create(context.TODO(), &v1.VirtualMachineInstance{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1.GroupVersion.String(),
@@ -448,10 +487,7 @@ func CreateVMI(client *kubevirtv1.KubevirtV1Client, name string, label map[strin
 			TerminationGracePeriodSeconds: &delSeconds,
 			Domain: v1.DomainSpec{
 				Resources: v1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("4096Mi"),
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-					},
+					Requests: resourceRequests,
 				},
 				CPU: &v1.CPU{
 					Sockets: sockets,
@@ -565,7 +601,7 @@ func (v *VirtctlClient) Run(command string) ([]byte, error) {
 	}
 	identityFile := fmt.Sprintf("%s/.ssh/id_rsa", dir)
 	log.Debugf("Running command %s against %s", command, v.vmName)
-	cmd := exec.Command(virtctlPath, "ssh", "--namespace", v.namespace, "--local-ssh-opts", "-o StrictHostKeyChecking=no", "--identity-file", identityFile, "-c", command, fmt.Sprintf("fedora@vmi/%s", v.vmName))
+	cmd := exec.Command(virtctlPath, "ssh", "--namespace", v.namespace, "--local-ssh-opts", "-o StrictHostKeyChecking=no", "--local-ssh-opts", "-o UserKnownHostsFile=/dev/null", "--identity-file", identityFile, "-c", command, fmt.Sprintf("fedora@vmi/%s", v.vmName))
 	log.Debugf("Command: %s", cmd.String())
 	stdout, err := cmd.Output()
 	if err != nil {
@@ -580,6 +616,48 @@ func (v *VirtctlClient) Run(command string) ([]byte, error) {
 
 // Close is a no-op for compatibility with VMExecutor interface
 func (v *VirtctlClient) Close() error {
+	return nil
+}
+
+// ConfigureVMSriovIP extracts the SR-IOV IP from the virt-launcher pod's network-status
+// annotation and configures it inside the guest VM via virtctl ssh.
+func ConfigureVMSriovIP(vmName string, pod corev1.Pod) error {
+	ip, err := ExtractSriovIp(pod)
+	if err != nil {
+		return fmt.Errorf("failed to extract SR-IOV IP for VM %s: %v", vmName, err)
+	}
+	log.Infof("Configuring SR-IOV IP %s/24 on VM %s", ip, vmName)
+	vc := NewVirtctlClient(vmName, namespace)
+	// Wait for cloud-init to finish and SSH to be available
+	for i := 0; i < retry; i++ {
+		_, err = vc.Run("echo ready")
+		if err == nil {
+			break
+		}
+		log.Debugf("Waiting for SSH on VM %s (%d/%d)", vmName, i+1, retry)
+		time.Sleep(10 * time.Second)
+	}
+	if err != nil {
+		return fmt.Errorf("SSH not available on VM %s after %d attempts: %v", vmName, retry, err)
+	}
+	// Find the SR-IOV interface name (non-default, non-loopback)
+	// With VFIO passthrough it typically appears as enp<X>s0 or eth1
+	out, err := vc.Run("ls /sys/class/net | grep -v -e lo -e eth0 | head -1")
+	if err != nil {
+		return fmt.Errorf("failed to find SR-IOV interface on VM %s: %v, output: %s", vmName, err, string(out))
+	}
+	iface := strings.TrimSpace(string(out))
+	if iface == "" {
+		return fmt.Errorf("no SR-IOV interface found on VM %s", vmName)
+	}
+	log.Infof("Found SR-IOV interface %s on VM %s", iface, vmName)
+	// Configure the IP address on the SR-IOV interface using nmcli for persistence
+	cmd := fmt.Sprintf("sudo nmcli con add type ethernet ifname %s con-name sriov-netperf ip4 %s/24 && sudo nmcli con up sriov-netperf", iface, ip)
+	out, err = vc.Run(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to configure SR-IOV IP on VM %s: %v, output: %s", vmName, err, string(out))
+	}
+	log.Infof("Successfully configured SR-IOV IP %s on %s in VM %s", ip, iface, vmName)
 	return nil
 }
 

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -49,6 +49,7 @@ type Data struct {
 	ExternalServer    bool
 	UdnInfo           string
 	BridgeInfo        string
+	SriovInfo         string
 	Virt              bool
 }
 
@@ -195,13 +196,13 @@ func calDiff(a float64, b float64) float64 {
 
 // ShowPodCPU accepts ScenarioResults and presents to the user via stdout the PodCPU info
 func ShowPodCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -209,13 +210,13 @@ func ShowPodCPU(s ScenarioResults) {
 
 // ShowPodMem accepts ScenarioResults and presents to the user via stdout the Podmem info
 func ShowPodMem(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -223,7 +224,7 @@ func ShowPodMem(s ScenarioResults) {
 
 // ShowNodeCPU accepts ScenarioResults and presents to the user via stdout the NodeCPU info
 func ShowNodeCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
 	for _, r := range s.Results {
 		// Skip RR/CRR iperf3 Results
 		if strings.Contains(r.Profile, "RR") {
@@ -234,11 +235,11 @@ func ShowNodeCPU(s ScenarioResults) {
 		ccpu := r.ClientMetrics
 		scpu := r.ServerMetrics
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", ccpu.Idle), fmt.Sprintf("%f", ccpu.User), fmt.Sprintf("%f", ccpu.System), fmt.Sprintf("%f", ccpu.Steal), fmt.Sprintf("%f", ccpu.Iowait), fmt.Sprintf("%f", ccpu.Nice), fmt.Sprintf("%f", ccpu.Softirq), fmt.Sprintf("%f", ccpu.Irq),
 		})
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", scpu.Idle), fmt.Sprintf("%f", scpu.User), fmt.Sprintf("%f", scpu.System), fmt.Sprintf("%f", scpu.Steal), fmt.Sprintf("%f", scpu.Iowait), fmt.Sprintf("%f", scpu.Nice), fmt.Sprintf("%f", scpu.Softirq), fmt.Sprintf("%f", scpu.Irq),
 		})
 	}
@@ -247,15 +248,15 @@ func ShowNodeCPU(s ScenarioResults) {
 
 // ShowSpecificResults
 func ShowSpecificResults(s ScenarioResults) {
-	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
+	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, "TCP_STREAM") {
 			rt, _ := Average(r.RetransmitSummary)
-			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
+			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
 		}
 		if strings.Contains(r.Profile, "UDP_STREAM") {
 			loss, _ := Average(r.LossSummary)
-			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
+			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
 		}
 	}
 	table.Render()
@@ -263,7 +264,7 @@ func ShowSpecificResults(s ScenarioResults) {
 
 // Abstracts out the common code for results
 func renderResults(s ScenarioResults, testType string) {
-	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
+	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, testType) {
 			if len(r.Driver) > 0 {
@@ -272,7 +273,7 @@ func renderResults(s ScenarioResults, testType string) {
 				if r.Samples > 1 {
 					_, lo, hi = ConfidenceInterval(r.ThroughputSummary, 0.95)
 				}
-				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
+				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
 			}
 		}
 	}
@@ -301,11 +302,11 @@ func ShowRRResult(s ScenarioResults) {
 func ShowLatencyResult(s ScenarioResults) {
 	if checkResults(s, "RR") {
 		logging.Debug("Rendering RR P99 Latency results")
-		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
+		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
 				p99, _ := Average(r.LatencySummary)
-				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
+				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
 			}
 		}
 		table.Render()


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds --sriov flag to run network performance tests over SR-IOV VFs. When specified, k8s-netperf creates SriovNetworkNodePolicy and SriovNetwork CRs, waits for the NAD and deploys pods with SR-IOV network annotations and VF resource requests. Applies disableDrain on the SriovOperatorConfig to avoid node drain/reboot during VF configuration.

## Related Tickets & Documents

- Closes https://github.com/cloud-bulldozer/k8s-netperf/issues/222

## Testing
Tested on an SNO:

```
/root/k8s-netperf-linux --local --config /root/sriov-test.yml --sriov ens2f0np0
INFO[2026-03-26 10:56:13] Starting k8s-netperf (@)                     
INFO[2026-03-26 10:56:13] 📒 Reading /root/sriov-test.yml file.         
INFO[2026-03-26 10:56:13] 📒 Reading /root/sriov-test.yml file - using ConfigV2 Method.  
INFO[2026-03-26 10:56:13] Cleaning up SR-IOV resources                 
WARN[2026-03-26 10:56:13] Failed to delete SriovNetwork: sriovnetworks.sriovnetwork.openshift.io "sriov-netperf" not found 
WARN[2026-03-26 10:56:13] Failed to delete SriovNetworkNodePolicy: sriovnetworknodepolicies.sriovnetwork.openshift.io "sriov-netperf-policy" not found 
INFO[2026-03-26 10:56:13] 🔬 prometheus discovered at openshift-monitoring 
INFO[2026-03-26 10:56:13] 🔨 Creating namespace: netperf                
INFO[2026-03-26 10:56:13] 🔨 Creating service account: netperf          
INFO[2026-03-26 10:56:13] Applying SriovOperatorConfig with disableDrain: true 
W0326 10:56:13.933682   83776 warnings.go:70] Node draining is disabled for applying SriovNetworkNodePolicy, it may result in workload interruption.
INFO[2026-03-26 10:56:13] Deploying SriovNetworkNodePolicy for PF: ens2f0np0 
INFO[2026-03-26 10:56:13] Deploying SriovNetwork with resourceName: ens2f0np0 
INFO[2026-03-26 10:56:13] Waiting for SR-IOV NetworkAttachmentDefinition sriov-netperf in namespace netperf... 
INFO[2026-03-26 10:56:18] SR-IOV NetworkAttachmentDefinition sriov-netperf is ready 
WARN[2026-03-26 10:56:18] ⚠️  No zone label                            
WARN[2026-03-26 10:56:18] ⚠️  Single node per zone and/or no zone labels 
INFO[2026-03-26 10:56:18] 🌉 Configuring SR-IOV network: netperf/sriov-netperf 
INFO[2026-03-26 10:56:18] 🚀 Starting Deployment for: client in namespace: netperf 
INFO[2026-03-26 10:56:18] ⏰ Checking for client Pods to become ready... 
INFO[2026-03-26 10:56:58] Looking for pods with label role=client-local 
INFO[2026-03-26 10:56:58] 🚀 Creating service for netperf-service in namespace netperf 
INFO[2026-03-26 10:56:58] 🌉 Configuring SR-IOV network: netperf/sriov-netperf 
INFO[2026-03-26 10:56:58] 🚀 Starting Deployment for: server in namespace: netperf 
INFO[2026-03-26 10:56:58] ⏰ Checking for server Pods to become ready... 
INFO[2026-03-26 10:57:00] Looking for pods with label role=server      
INFO[2026-03-26 10:57:05] 🗒️  Running netperf TCP_STREAM (service false) for 10s  
INFO[2026-03-26 10:57:17] 🗒️  Running netperf TCP_RR (service false) for 10s  
+-------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO |   SR-IOV INFO   | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |      AVG VALUE      | 95% CONFIDENCE INTERVAL  |
+-------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false     | false   | false           |          |             | sriov/ens2f0np0 | 1024         | 0     | true      | 10       | 1       | 21252.280000 (Mb/s) | 0.000000-0.000000 (Mb/s) |
+-------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
+---------------+---------+----------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
|  RESULT TYPE  | DRIVER  | SCENARIO | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO |   SR-IOV INFO   | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |      AVG VALUE      | 95% CONFIDENCE INTERVAL  |
+---------------+---------+----------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
| 📊 Rr Results | netperf | TCP_RR   | 1           | false        | false     | false   | false           |          |             | sriov/ens2f0np0 | 1024         | 0     | true      | 10       | 1       | 32388.710000 (OP/s) | 0.000000-0.000000 (OP/s) |
+---------------+---------+----------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
+--------------------+---------+----------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+-------------------+
|    RESULT TYPE     | DRIVER  | SCENARIO | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO |   SR-IOV INFO   | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES | AVG 99%TILE VALUE |
+--------------------+---------+----------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+-------------------+
| RR Latency Results | netperf | TCP_RR   | 1           | false        | false     | false   | false           |          |             | sriov/ens2f0np0 | 1024         | 0     | true      | 10       | 1       | 41.000000 (usec)  |
+--------------------+---------+----------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+-------------------+
+---------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+-----------+
|        TYPE         | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO |   SR-IOV INFO   | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES | AVG VALUE |
+---------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+-----------+
| TCP Retransmissions | netperf | TCP_STREAM | 1           | false        | false     | false   | false           |          |             | sriov/ens2f0np0 | 1024         | 0     | true      | 10       | 1       | 0.000000  |
+---------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-----------------+--------------+-------+-----------+----------+---------+-----------+
INFO[2026-03-26 10:57:29] Cleaning up SR-IOV resources                 
INFO[2026-03-26 10:57:29] Cleaning resources created by k8s-netperf    
INFO[2026-03-26 10:57:29] ⏰ Waiting for netperf Namespace to be deleted... 
```


```
c -n netperf get pods -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: Pod
  metadata:
    annotations:
      k8s.v1.cni.cncf.io/networks: netperf/sriov-netperf
      openshift.io/scc: restricted-v2
      seccomp.security.alpha.kubernetes.io/pod: runtime/default
      security.openshift.io/validated-scc-subject-type: user
      sidecar.istio.io/inject: "true"
    creationTimestamp: "2026-03-26T10:56:19Z"
    generateName: client-57bcb94788-
    generation: 1
    labels:
      pod-template-hash: 57bcb94788
      role: client-local
    name: client-57bcb94788-hd6pw
    namespace: netperf
    ownerReferences:
    - apiVersion: apps/v1
      blockOwnerDeletion: true
      controller: true
      kind: ReplicaSet
      name: client-57bcb94788
      uid: 10f64622-f6f0-43da-9f85-baa8dda551e9
    resourceVersion: "144254"
    uid: 8afe4d30-3deb-4536-87c8-4237adcb8a5f
  spec:
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: node-role.kubernetes.io/worker
              operator: In
              values:
              - ""
            - key: node-role.kubernetes.io/infra
              operator: NotIn
              values:
              - ""
            - key: node-role.kubernetes.io/workload
              operator: NotIn
              values:
              - ""
      podAffinity: {}
      podAntiAffinity: {}
    containers:
    - command:
      - /bin/bash
      - -c
      - sleep 10000000
      image: quay.io/cloud-bulldozer/k8s-netperf:latest
      imagePullPolicy: Always
      name: client-0
      resources:
        limits:
          openshift.io/ens2f0np0: "1"
        requests:
          openshift.io/ens2f0np0: "1"
      securityContext:
        allowPrivilegeEscalation: false
        capabilities:
          drop:
          - ALL
        runAsNonRoot: true
        runAsUser: 1000820000
```
