### PR TITLE
Feature/cluster customization and observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin/
 # vendor/
 
 dist/
+.vscode/
+.claude/

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/virtctl"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -62,6 +63,13 @@ var (
 	sriov             string
 	sriovNodeSelector string
 	macvlan           string
+	kubeconfig        string
+	netperfNamespace  string
+	namespaceFile     string
+	nodeSelectors     []string
+	tolerationKeys    []string
+	autoTolerate      bool
+	tags              []string
 	promURL           string
 	id                string
 	searchURL         string
@@ -199,12 +207,16 @@ var rootCmd = &cobra.Command{
 			cfg = cf
 		}
 		// Read in k8s config
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		if kubeconfig != "" {
+			loadingRules.ExplicitPath = kubeconfig
+		}
 		kconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			clientcmd.NewDefaultClientConfigLoadingRules(),
+			loadingRules,
 			&clientcmd.ConfigOverrides{})
 		rconfig, err := kconfig.ClientConfig()
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("😭 Unable to load kubeconfig: %v. Use --kubeconfig to specify the path or set KUBECONFIG env variable.", err)
 		}
 		client, err := kubernetes.NewForConfig(rconfig)
 		if err != nil {
@@ -224,6 +236,71 @@ var rootCmd = &cobra.Command{
 		} else {
 			log.Warnf("Cluster metadata client unavailable: %v", err)
 		}
+
+		// If a namespace file is provided, read the namespace name from it
+		if namespaceFile != "" {
+			nsName, err := k8s.ReadNamespaceFromFile(namespaceFile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			netperfNamespace = nsName
+			log.Infof("📁 Using namespace %q from file: %s", netperfNamespace, namespaceFile)
+		}
+
+		// Configure namespace override
+		k8s.SetNamespace(netperfNamespace)
+
+		// Parse node selectors from CLI flags (key=value pairs)
+		parsedNodeSelectors := make(map[string]string)
+		for _, sel := range nodeSelectors {
+			parts := strings.SplitN(sel, "=", 2)
+			if len(parts) != 2 {
+				log.Fatalf("😭 Invalid node selector format %q, expected key=value", sel)
+			}
+			parsedNodeSelectors[parts[0]] = parts[1]
+		}
+
+		// Build tolerations from CLI flags
+		var tolerations []corev1.Toleration
+		for _, key := range tolerationKeys {
+			tolerations = append(tolerations, corev1.Toleration{
+				Key:      key,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			})
+		}
+
+		// Auto-tolerate: discover taints from given node selectors nodes
+		if autoTolerate {
+			seenTaintKeys := make(map[string]bool)
+			for _, key := range tolerationKeys {
+				seenTaintKeys[key] = true
+			}
+			for labelKey, labelVal := range parsedNodeSelectors {
+				labelSel := labelKey + "=" + labelVal
+				labeledNodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSel})
+				if err != nil {
+					log.Warnf("⚠️  Unable to list nodes with label %s for auto-tolerate: %v", labelSel, err)
+					continue
+				}
+				for _, node := range labeledNodes.Items {
+					for _, taint := range node.Spec.Taints {
+						if seenTaintKeys[taint.Key] {
+							continue
+						}
+						seenTaintKeys[taint.Key] = true
+						log.Infof("🔧 Auto-tolerating taint %s=%s:%s from node %s", taint.Key, taint.Value, taint.Effect, node.Name)
+						tolerations = append(tolerations, corev1.Toleration{
+							Key:      taint.Key,
+							Value:    taint.Value,
+							Operator: corev1.TolerationOpEqual,
+							Effect:   taint.Effect,
+						})
+					}
+				}
+			}
+		}
+
 		if clean {
 			cleanup(client, rconfig)
 		}
@@ -232,6 +309,9 @@ var rootCmd = &cobra.Command{
 			HostNetworkOnly: hostNetOnly,
 			NodeLocal:       nl,
 			AcrossAZ:        acrossAZ,
+			Namespace:       netperfNamespace,
+			NodeSelectors:   parsedNodeSelectors,
+			Tolerations:     tolerations,
 			RestConfig:      *rconfig,
 			Configs:         cfg,
 			ClientSet:       client,
@@ -249,8 +329,9 @@ var rootCmd = &cobra.Command{
 		if serverIPAddr != "" {
 			s.ExternalServer = true
 		}
-		// Get node count
-		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker="})
+		// Get node count using the same selector logic as pod scheduling
+		nodeCountSelector := k8s.NodeLabelSelector(s.NodeSelectors)
+		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nodeCountSelector})
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -268,6 +349,9 @@ var rootCmd = &cobra.Command{
 		}
 		if promURL != "" {
 			pcon.URL = promURL
+		} else {
+			// Try OpenShift auto-discovery
+			pcon, _ = metrics.Discover(rconfig)
 		}
 		applyClusterDistribution(&pcon, clusterInfo.Metadata.Distribution)
 		if pcon.URL == "" {
@@ -282,7 +366,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Build the namespace and create the sa account
-		err = k8s.BuildInfra(client, udnl2 || udnl3)
+		err = k8s.BuildInfra(client, udnl2 || udnl3, namespaceFile)
 		if err != nil {
 			log.Error(err)
 			os.Exit(1)
@@ -442,8 +526,9 @@ var rootCmd = &cobra.Command{
 
 		sr.Version = cmdVersion.Version
 		sr.GitCommit = cmdVersion.GitCommit
+		sr.Tags = tags
 		// If the client and server needs to be across zones
-		lz, zones, err := k8s.GetZone(client)
+		lz, zones, err := k8s.GetZone(client, k8s.NodeLabelSelector(s.NodeSelectors))
 		if s.NodeLocal || err != nil || len(zones) == 0 {
 			acrossAZ = false
 		} else {
@@ -581,7 +666,10 @@ var rootCmd = &cobra.Command{
 				log.Error(err)
 			}
 		}
-		if csvArchive {
+		// Only write CSV files when --csv is explicitly set by the user,
+		// or when neither --json nor --search is used (backward-compatible default).
+		writeCSV := csvArchive && (cmd.Flags().Changed("csv") || (!json && len(searchURL) < 2))
+		if writeCSV {
 			if err := archive.WriteCSVResult(sr); err != nil {
 				log.Fatal(err)
 			}
@@ -596,7 +684,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		if searchURL != "" {
-			jdocs, err := archive.BuildDocs(sr, uid)
+			jdocs, err := archive.BuildDocs(sr, uid, tags)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -914,6 +1002,7 @@ func executeWorkload(nc config.Config,
 }
 
 func main() {
+	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file (defaults to KUBECONFIG env or ~/.kube/config)")
 	rootCmd.Flags().StringVar(&cfgfile, "config", "netperf.yml", "K8s netperf Configuration File")
 	rootCmd.Flags().BoolVar(&netperf, "netperf", true, "Use netperf as load driver (default true)")
 	rootCmd.Flags().BoolVar(&iperf3, "iperf", false, "Use iperf3 as load driver (default false)")
@@ -943,9 +1032,15 @@ func main() {
 	rootCmd.Flags().StringVar(&bridgeNetwork, "bridgeNetwork", "bridgeNetwork.json", "Json file for the VM network defined by the bridge interface - bridge should be enabled (default bridgeNetwork.json)")
 	rootCmd.Flags().StringVar(&sriov, "sriov", "", "SR-IOV PF interface name (e.g., ens1f0). Creates SriovNetworkNodePolicy and SriovNetwork CRs. Requires SR-IOV operator.")
 	rootCmd.Flags().StringVar(&sriovNodeSelector, "sriov-node-selector", "worker", "Node role label for SR-IOV node selector (default worker)")
+	rootCmd.Flags().StringVar(&netperfNamespace, "namespace", k8s.DefaultNamespace, "Kubernetes namespace for netperf resources (default netperf)")
+	rootCmd.Flags().StringVar(&namespaceFile, "namespace-file", "", "Path to a YAML file defining the namespace to create (metadata.name must match --namespace)")
+	rootCmd.Flags().StringSliceVar(&nodeSelectors, "node-selector", nil, "Additional node selector as key=value to constrain pod scheduling and node count checks (can be specified multiple times)")
+	rootCmd.Flags().StringSliceVar(&tolerationKeys, "toleration", nil, "Toleration key to add to netperf pods (can be specified multiple times, e.g. --toleration=key1 --toleration=key2)")
+	rootCmd.Flags().BoolVar(&autoTolerate, "auto-tolerate", false, "Automatically add tolerations for taints found on nodes matching netperf=server and netperf=client labels (default false)")
 	rootCmd.Flags().StringVar(&macvlan, "macvlan", "", "MACVLAN master interface name (e.g., eth0). Creates a MACVLAN NetworkAttachmentDefinition.")
 	rootCmd.Flags().StringVar(&promURL, "prom", "", "Prometheus URL")
 	rootCmd.Flags().StringVar(&id, "uuid", "", "User provided UUID")
+	rootCmd.Flags().StringSliceVar(&tags, "tag", nil, "Tags to attach to indexed results for filtering in dashboards (can be specified multiple times, e.g. --tag=baseline --tag=cluster-a)")
 	rootCmd.Flags().StringVar(&searchURL, "search", "", "OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port")
 	rootCmd.Flags().StringVar(&searchIndex, "index", "", "OpenSearch Index to save the results to (default k8s-netperf)")
 	rootCmd.Flags().BoolVar(&showMetrics, "metrics", false, "Show all system metrics retrieved from prom (default false)")

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -242,11 +242,16 @@ var rootCmd = &cobra.Command{
 			log.Warnf("Cluster metadata client unavailable: %v", err)
 		}
 
-		// If a namespace file is provided, read the namespace name from it
+		// If a namespace file is provided, read the namespace name from it.
+		// The file value takes precedence, but if --namespace was also set
+		// explicitly it must match to catch typos in either flag.
 		if namespaceFile != "" {
 			nsName, err := k8s.ReadNamespaceFromFile(namespaceFile)
 			if err != nil {
 				log.Fatal(err)
+			}
+			if cmd.Flags().Changed("namespace") && nsName != netperfNamespace {
+				log.Fatalf("namespace mismatch: --namespace=%q but --namespace-file metadata.name=%q; set them to the same value or omit --namespace", netperfNamespace, nsName)
 			}
 			netperfNamespace = nsName
 			log.Infof("📁 Using namespace %q from file: %s", netperfNamespace, namespaceFile)
@@ -268,27 +273,26 @@ var rootCmd = &cobra.Command{
 		// Build tolerations from CLI flags
 		var tolerations []corev1.Toleration
 		for _, key := range tolerationKeys {
+			// Leave Effect unset so the key matches taints with any effect.
 			tolerations = append(tolerations, corev1.Toleration{
 				Key:      key,
 				Operator: corev1.TolerationOpExists,
-				Effect:   corev1.TaintEffectNoSchedule,
 			})
 		}
 
-		// Auto-tolerate: discover taints from given node selectors nodes
+		// Auto-tolerate: discover taints from the same ANDed target node set
+		// used for pod scheduling (with worker-node fallback).
 		if autoTolerate {
 			seenTaintKeys := make(map[string]bool)
 			for _, key := range tolerationKeys {
 				seenTaintKeys[key] = true
 			}
-			for labelKey, labelVal := range parsedNodeSelectors {
-				labelSel := labelKey + "=" + labelVal
-				labeledNodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSel})
-				if err != nil {
-					log.Warnf("⚠️  Unable to list nodes with label %s for auto-tolerate: %v", labelSel, err)
-					continue
-				}
-				for _, node := range labeledNodes.Items {
+			nodeSel := k8s.NodeLabelSelector(parsedNodeSelectors)
+			targetNodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nodeSel})
+			if err != nil {
+				log.Warnf("⚠️  Unable to list nodes matching selector %q for auto-tolerate: %v", nodeSel, err)
+			} else {
+				for _, node := range targetNodes.Items {
 					for _, taint := range node.Spec.Taints {
 						if seenTaintKeys[taint.Key] {
 							continue
@@ -671,7 +675,7 @@ var rootCmd = &cobra.Command{
 		}
 		// Only write CSV files when --csv is explicitly set by the user,
 		// or when neither --json nor --search is used (backward-compatible default).
-		writeCSV := csvArchive && (cmd.Flags().Changed("csv") || (!json && len(searchURL) < 2))
+		writeCSV := csvArchive && (cmd.Flags().Changed("csv") || (!json && searchURL == ""))
 		if writeCSV {
 			if err := archive.WriteCSVResult(sr); err != nil {
 				log.Fatal(err)
@@ -1036,15 +1040,15 @@ func main() {
 	rootCmd.Flags().StringVar(&sriov, "sriov", "", "SR-IOV PF interface name (e.g., ens1f0). Creates SriovNetworkNodePolicy and SriovNetwork CRs. Requires SR-IOV operator.")
 	rootCmd.Flags().StringVar(&sriovNodeSelector, "sriov-node-selector", "worker", "Node role label for SR-IOV node selector (default worker)")
 	rootCmd.Flags().StringVar(&netperfNamespace, "namespace", k8s.DefaultNamespace, "Kubernetes namespace for netperf resources (default netperf)")
-	rootCmd.Flags().StringVar(&namespaceFile, "namespace-file", "", "Path to a YAML file defining the namespace to create (metadata.name must match --namespace)")
+	rootCmd.Flags().StringVar(&namespaceFile, "namespace-file", "", "Path to a YAML file defining the namespace to create; its metadata.name takes precedence over --namespace (must match if --namespace is also set)")
 	rootCmd.Flags().StringSliceVar(&nodeSelectors, "node-selector", nil, "Additional node selector as key=value to constrain pod scheduling and node count checks (can be specified multiple times)")
 	rootCmd.Flags().StringSliceVar(&tolerationKeys, "toleration", nil, "Toleration key to add to netperf pods (can be specified multiple times, e.g. --toleration=key1 --toleration=key2)")
-	rootCmd.Flags().BoolVar(&autoTolerate, "auto-tolerate", false, "Automatically add tolerations for taints found on nodes matching netperf=server and netperf=client labels (default false)")
+	rootCmd.Flags().BoolVar(&autoTolerate, "auto-tolerate", false, "Automatically add tolerations for taints found on nodes matching --node-selector (or worker nodes by default) (default false)")
 	rootCmd.Flags().StringVar(&macvlan, "macvlan", "", "MACVLAN master interface name (e.g., eth0). Creates a MACVLAN NetworkAttachmentDefinition.")
 	rootCmd.Flags().StringVar(&promURL, "prom", "", "Prometheus URL")
 	rootCmd.Flags().StringVar(&id, "uuid", "", "User provided UUID")
 	rootCmd.Flags().StringSliceVar(&tags, "tag", nil, "Tags to attach to indexed results for filtering in dashboards (can be specified multiple times, e.g. --tag=baseline --tag=cluster-a)")
-	rootCmd.Flags().StringVar(&searchURL, "search", "", "OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port")
+	rootCmd.Flags().StringVar(&searchURL, "search", "", "OpenSearch URL (basic auth supported; avoid embedding credentials in the URL on shared hosts - see docs/setup.md)")
 	rootCmd.Flags().StringVar(&searchIndex, "index", "", "OpenSearch Index to save the results to (default k8s-netperf)")
 	rootCmd.Flags().BoolVar(&showMetrics, "metrics", false, "Show all system metrics retrieved from prom (default false)")
 	rootCmd.Flags().Float64Var(&tcpt, "tcp-tolerance", 10, "Allowed %diff from hostNetwork to podNetwork, anything above tolerance will result in k8s-netperf exiting 1 (default 10)")

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -176,6 +176,11 @@ var rootCmd = &cobra.Command{
 			u := uuid.New()
 			uid = u.String()
 		}
+		// short DNS-safe suffix for run-scoped resource names
+		runID := strings.ToLower(strings.ReplaceAll(uid, "-", ""))
+		if len(runID) > 8 {
+			runID = runID[:8]
+		}
 
 		if json {
 			log.SetError()
@@ -310,6 +315,7 @@ var rootCmd = &cobra.Command{
 			NodeLocal:       nl,
 			AcrossAZ:        acrossAZ,
 			Namespace:       netperfNamespace,
+			RunID:           runID,
 			NodeSelectors:   parsedNodeSelectors,
 			Tolerations:     tolerations,
 			RestConfig:      *rconfig,
@@ -349,9 +355,6 @@ var rootCmd = &cobra.Command{
 		}
 		if promURL != "" {
 			pcon.URL = promURL
-		} else {
-			// Try OpenShift auto-discovery
-			pcon, _ = metrics.Discover(rconfig)
 		}
 		applyClusterDistribution(&pcon, clusterInfo.Metadata.Distribution)
 		if pcon.URL == "" {

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -49,6 +49,24 @@ The service account and hostnetwork role binding are always created automaticall
 
 > *Note: When `--clean=true` (the default), k8s-netperf deletes the namespace at startup to remove leftover resources from previous runs, then recreates it. Pass `--clean=false` to skip this.*
 
+## Concurrent Runs in the Same Namespace
+
+k8s-netperf scopes all deployments, services, pod labels, and pod-affinity selectors to a per-run ID derived from the run UUID. This means multiple k8s-netperf instances can run side by side in the same namespace without colliding on resource names or routing service traffic to the wrong pods.
+
+Each run produces resources named like `client-<runID>`, `server-<runID>`, `netperf-service-<runID>`, etc. Pods carry a `k8s-netperf/run-id=<runID>` label, and service selectors plus PodAntiAffinity rules match on that label so each run only sees its own pods.
+
+**Required for concurrent runs:** pass `--clean=false`. The default cleanup deletes the entire namespace at both startup and shutdown, which would terminate any other in-flight run sharing the namespace.
+
+```shell
+# Run A
+$ k8s-netperf --namespace shared-perf --clean=false --tag baseline ...
+
+# Run B in parallel
+$ k8s-netperf --namespace shared-perf --clean=false --tag experimental ...
+```
+
+Use `--uuid` to fix the run ID if you want predictable resource names. Otherwise k8s-netperf generates a fresh UUID per run.
+
 ```shell
 $ kubectl create ns netperf
 $ kubectl create sa -n netperf netperf

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,7 +39,15 @@ $ oc label nodes node-name netperf=server
 ## Running with Pods
 Ensure your `kubeconfig` is properly set to the cluster you would like to run `k8s-netperf` against.
 
-also be sure to create a `netperf` namespace. (Not over-writable yet)
+The namespace can be created in three ways:
+
+- **Automatically** (default) -- k8s-netperf creates it with default labels.
+- **From a file** -- pass `--namespace-file namespace.yaml` to create it from your own YAML manifest (e.g. with custom labels or annotations). The `metadata.name` in the file must match `--namespace`.
+- **Manually** -- create the namespace yourself before running k8s-netperf with `--clean=false` so it is not deleted on startup.
+
+The service account and hostnetwork role binding are always created automatically.
+
+> *Note: When `--clean=true` (the default), k8s-netperf deletes the namespace at startup to remove leftover resources from previous runs, then recreates it. Pass `--clean=false` to skip this.*
 
 ```shell
 $ kubectl create ns netperf
@@ -76,53 +84,73 @@ Usage:
   k8s-netperf [flags]
 
 Flags:
-      --config string             K8s netperf Configuration File (default "netperf.yml")
-      --netperf                   Use netperf as load driver (default true)
-      --iperf                     Use iperf3 as load driver
-      --uperf                     Use uperf as load driver
-      --ib-write-bw string        Use ib_write_bw as load driver, requires nic:gid format (e.g., mlx5_0:0, requires --privileged and --hostNet)
-      --clean                     Clean-up resources created by k8s-netperf (default true)
-      --json                      Instead of human-readable output, return JSON to stdout
-      --local                     Run network performance tests with Server-Pods/Client-Pods on the same Node
-      --vm                        Launch Virtual Machines instead of pods for client/servers
-      --vm-image string           Use specified VM image (default "quay.io/containerdisks/fedora:39")
-      --sockets uint32            Number of Sockets for VM (default 2)
-      --cores uint32              Number of cores for VM (default 2)
-      --threads uint32            Number of threads for VM (default 1)
-      --across                    Place the client and server across availability zones
-      --all                       Run all tests scenarios - hostNet and podNetwork (if possible)
-      --hostNet                   Run only hostNetwork tests (no podNetwork tests)
-      --debug                     Enable debug log
-      --udnl2                     Create and use a layer2 UDN as a primary network.
-      --udnl3                     Create and use a layer3 UDN as a primary network.
-      --udnPluginBinding string   UDN with VMs only - the binding method of the UDN interface, select 'passt' or 'l2bridge' (default "passt")
-      --bridge string             Name of the NetworkAttachmentDefinition to be used for bridge interface
-      --bridgeNamespace string    Namespace of the NetworkAttachmentDefinition for bridge interface (default "default")
-      --bridgeNetwork string      Json file for the VM network defined by the bridge interface - bridge should be enabled (default "bridgeNetwork.json")
-      --prom string               Prometheus URL
-      --uuid string               User provided UUID
-      --search string             OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port
-      --index string              OpenSearch Index to save the results to, defaults to k8s-netperf
-      --metrics                   Show all system metrics retrieved from prom
-      --tcp-tolerance float       Allowed %diff from hostNetwork to podNetwork, anything above tolerance will result in k8s-netperf exiting 1. (default 10)
-      --version                   k8s-netperf version
-      --csv                       Archive results, cluster and benchmark metrics in CSV files (default true)
-      --serverIP string           External Server IP Address
-      --privileged                Run pods with privileged security context
-  -h, --help                      help for k8s-netperf
+      --kubeconfig string           Path to the kubeconfig file (defaults to KUBECONFIG env or ~/.kube/config)
+      --config string               K8s netperf Configuration File (default "netperf.yml")
+      --netperf                     Use netperf as load driver (default true)
+      --iperf                       Use iperf3 as load driver
+      --uperf                       Use uperf as load driver
+      --ib-write-bw string          Use ib_write_bw as load driver, requires nic:gid format (e.g., mlx5_0:0, requires --privileged and --hostNet)
+      --clean                       Clean-up resources created by k8s-netperf (default true)
+      --json                        Instead of human-readable output, return JSON to stdout
+      --local                       Run network performance tests with Server-Pods/Client-Pods on the same Node
+      --pod                         Run tests using pods (default true)
+      --vm                          Run tests using Virtual Machines
+      --vm-image string             Use specified VM image (default "quay.io/containerdisks/fedora:39")
+      --use-virtctl                 Use virtctl ssh for VM connections instead of traditional SSH
+      --sockets uint32              Number of Sockets for VM (default 2)
+      --cores uint32                Number of cores for VM (default 2)
+      --threads uint32              Number of threads for VM (default 1)
+      --across                      Place the client and server across availability zones
+      --all                         Run all tests scenarios - hostNet and podNetwork (if possible)
+      --hostNet                     Run only hostNetwork tests (no podNetwork tests)
+      --debug                       Enable debug log
+      --udnl2                       Create and use a layer2 UDN as a primary network
+      --udnl3                       Create and use a layer3 UDN as a primary network
+      --cudn string                 Create and use a Cluster UDN as a secondary network
+      --udnPluginBinding string     UDN with VMs only - the binding method of the UDN interface, select 'passt' or 'l2bridge' (default "passt")
+      --bridge string               Name of the NetworkAttachmentDefinition to be used for bridge interface
+      --bridgeNamespace string      Namespace of the NetworkAttachmentDefinition for bridge interface (default "default")
+      --bridgeNetwork string        Json file for the VM network defined by the bridge interface (default "bridgeNetwork.json")
+      --sriov string                SR-IOV PF interface name (e.g., ens1f0). Requires SR-IOV operator
+      --sriov-node-selector string  Node role label for SR-IOV node selector (default "worker")
+      --namespace string            Kubernetes namespace for netperf resources (default "netperf")
+      --namespace-file string       Path to a YAML file defining the namespace to create (namespace name is read from the file)
+      --node-selector strings       Node selector as key=value to control pod scheduling and node count checks (can be repeated)
+      --toleration strings          Toleration key to add to netperf pods (can be repeated)
+      --auto-tolerate               Automatically add tolerations for taints found on netperf=server and netperf=client nodes
+      --tag strings                 Tags to attach to indexed results for filtering in dashboards (can be repeated)
+      --prom string                 Prometheus URL
+      --uuid string                 User provided UUID
+      --search string               OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port
+      --index string                OpenSearch Index to save the results to (default "k8s-netperf")
+      --metrics                     Show all system metrics retrieved from prom
+      --tcp-tolerance float         Allowed %diff from hostNetwork to podNetwork (default 10)
+      --version                     k8s-netperf version
+      --csv                         Archive results in CSV files (default true, disabled when --json or --search is used)
+      --serverIP string             External Server IP Address
+      --privileged                  Run pods with privileged security context
+  -h, --help                        help for k8s-netperf
 ```
 
 ## Flag Details
 
-- `--across` will force the client to be across availability zones from the server
-- `--json` will reduce all output to just the JSON result, allowing users to feed the result to `jq` or other tools. Only output to the screen will be the result JSON or errors.
-- `--clean=true` will delete all the resources the project creates (deployments and services)
-- `--serverIP` accepts a string (IP Address). Example  44.243.95.221. k8s-netperf assumes this as server address and the client sends requests to this IP address.
-- `--prom` accepts a string (URL). Example  http://localhost:9090
-  - When using `--prom` with a non-openshift cluster, it will be necessary to pass the prometheus URL.
+- `--kubeconfig` path to the kubeconfig file. If not set, uses the `KUBECONFIG` environment variable or falls back to `~/.kube/config`.
+- `--across` will force the client to be across availability zones from the server.
+- `--json` will reduce all output to just the JSON result, allowing users to feed the result to `jq` or other tools. Only output to the screen will be the result JSON or errors. CSV files are not generated unless `--csv` is explicitly set.
+- `--clean=true` will delete the namespace and all resources at startup and after tests complete. Pass `--clean=false` to preserve the namespace between runs.
+- `--serverIP` accepts a string (IP Address). Example: `44.243.95.221`. k8s-netperf assumes this as server address and the client sends requests to this IP address.
+- `--prom` accepts a string (URL). Example: `http://localhost:9090`. On non-OpenShift clusters, this is required to enable Prometheus metrics collection. On OpenShift, Prometheus is auto-discovered.
 - `--metrics` will enable displaying prometheus captured metrics to stdout. By default they will be written to a csv file.
 - `--iperf` will enable the iperf3 load driver for any stream test (TCP_STREAM, UDP_STREAM). iperf3 doesn't have a RR or CRR test-type.
 - `--uperf` will enable the uperf load driver for any stream test (TCP_STREAM, UDP_STREAM). uperf doesn't have CRR test-type.
 - `--ib-write-bw $NIC:$GID` will enable the ib-write-bw load driver for any stream UDP_STREAM tests. ib_write_bw doesn't have CRR test-type.
+- `--namespace` sets the Kubernetes namespace where all netperf resources (deployments, services, service accounts) are created. Defaults to `netperf`.
+- `--namespace-file` path to a YAML file defining the namespace. The namespace name is read from the file's `metadata.name` and used automatically. Allows custom labels, annotations, or other metadata on the namespace.
+- `--node-selector key=value` sets node label requirements for pod scheduling. When provided, replaces the default `node-role.kubernetes.io/worker=` selector. Also used for node count validation and zone detection. Can be repeated for multiple selectors.
+- `--toleration key` adds a `NoSchedule` toleration (with `Exists` operator) for the given taint key to all netperf pods. Can be repeated.
+- `--auto-tolerate` queries nodes labeled `netperf=server` and `netperf=client`, collects their taints, and automatically adds matching tolerations to all pods. Disabled by default. Deduplicates against any manual `--toleration` keys.
+- `--tag` attaches labels to indexed results (OpenSearch, JSON, CSV) for filtering and comparing different configurations in dashboards. Can be repeated (e.g. `--tag baseline --tag cluster-a`).
+- `--csv` archives results in CSV files. Enabled by default in human-readable mode. Automatically disabled when `--json` or `--search` is used, unless `--csv` is explicitly passed.
+- `--search` OpenSearch URL for indexing results. When set, CSV generation is skipped unless `--csv` is explicitly passed.
 
-> *Note: With OpenShift, we attempt to discover the OpenShift route. If that route is not reachable, it might be required to `port-forward` the service and pass that via the `--prom` option.*
+> *Note: On OpenShift, Prometheus is auto-discovered via the monitoring route. On non-OpenShift clusters, pass the Prometheus URL via `--prom`. If the OpenShift route is not reachable, it might be necessary to `port-forward` the service and pass the URL via `--prom`.*

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -42,10 +42,10 @@ Ensure your `kubeconfig` is properly set to the cluster you would like to run `k
 The namespace can be created in three ways:
 
 - **Automatically** (default) -- k8s-netperf creates it with default labels.
-- **From a file** -- pass `--namespace-file namespace.yaml` to create it from your own YAML manifest (e.g. with custom labels or annotations). The `metadata.name` in the file must match `--namespace`.
+- **From a file** -- pass `--namespace-file namespace.yaml` to create it from your own YAML manifest (e.g. with custom labels or annotations). The `metadata.name` in the file takes precedence over `--namespace`; if `--namespace` is also set explicitly, it must match.
 - **Manually** -- create the namespace yourself before running k8s-netperf with `--clean=false` so it is not deleted on startup.
 
-The service account and hostnetwork role binding are always created automatically.
+The service account and hostnetwork role binding are always created automatically, so you do not need to create them yourself.
 
 > *Note: When `--clean=true` (the default), k8s-netperf deletes the namespace at startup to remove leftover resources from previous runs, then recreates it. Pass `--clean=false` to skip this.*
 
@@ -67,22 +67,13 @@ $ k8s-netperf --namespace shared-perf --clean=false --tag experimental ...
 
 Use `--uuid` to fix the run ID if you want predictable resource names. Otherwise k8s-netperf generates a fresh UUID per run.
 
-```shell
-$ kubectl create ns netperf
-$ kubectl create sa -n netperf netperf
-```
+The namespace and service account are created automatically, so no manual `kubectl create ns`/`kubectl create sa` is needed. On OpenShift you still grant the required SCCs to the netperf service account.
 
 If you run with `--all`, you will need to allow `hostNetwork` for the netperf sa.
 
 Example
 ```shell
 $ oc adm policy add-scc-to-user hostnetwork -z netperf
-```
-
-Additional setup:
-```shell
-$ kubectl create ns netperf
-$ kubectl create sa netperf -n netperf
 ```
 
 Additional setup for the `--ib-write-bw` flag:
@@ -132,14 +123,14 @@ Flags:
       --sriov string                SR-IOV PF interface name (e.g., ens1f0). Requires SR-IOV operator
       --sriov-node-selector string  Node role label for SR-IOV node selector (default "worker")
       --namespace string            Kubernetes namespace for netperf resources (default "netperf")
-      --namespace-file string       Path to a YAML file defining the namespace to create (namespace name is read from the file)
+      --namespace-file string       Path to a YAML file defining the namespace to create; metadata.name takes precedence over --namespace (must match if --namespace is also set)
       --node-selector strings       Node selector as key=value to control pod scheduling and node count checks (can be repeated)
       --toleration strings          Toleration key to add to netperf pods (can be repeated)
-      --auto-tolerate               Automatically add tolerations for taints found on netperf=server and netperf=client nodes
+      --auto-tolerate               Automatically add tolerations for taints found on nodes matching --node-selector (or worker nodes by default)
       --tag strings                 Tags to attach to indexed results for filtering in dashboards (can be repeated)
       --prom string                 Prometheus URL
       --uuid string                 User provided UUID
-      --search string               OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port
+      --search string               OpenSearch URL (basic auth supported; avoid embedding credentials in the URL on shared hosts - see Flag Details)
       --index string                OpenSearch Index to save the results to (default "k8s-netperf")
       --metrics                     Show all system metrics retrieved from prom
       --tcp-tolerance float         Allowed %diff from hostNetwork to podNetwork (default 10)
@@ -163,12 +154,12 @@ Flags:
 - `--uperf` will enable the uperf load driver for any stream test (TCP_STREAM, UDP_STREAM). uperf doesn't have CRR test-type.
 - `--ib-write-bw $NIC:$GID` will enable the ib-write-bw load driver for any stream UDP_STREAM tests. ib_write_bw doesn't have CRR test-type.
 - `--namespace` sets the Kubernetes namespace where all netperf resources (deployments, services, service accounts) are created. Defaults to `netperf`.
-- `--namespace-file` path to a YAML file defining the namespace. The namespace name is read from the file's `metadata.name` and used automatically. Allows custom labels, annotations, or other metadata on the namespace.
+- `--namespace-file` path to a YAML file defining the namespace. The namespace name is read from the file's `metadata.name` and takes precedence over `--namespace`; if `--namespace` is also set explicitly it must match. Allows custom labels, annotations, or other metadata on the namespace.
 - `--node-selector key=value` sets node label requirements for pod scheduling. When provided, replaces the default `node-role.kubernetes.io/worker=` selector. Also used for node count validation and zone detection. Can be repeated for multiple selectors.
-- `--toleration key` adds a `NoSchedule` toleration (with `Exists` operator) for the given taint key to all netperf pods. Can be repeated.
-- `--auto-tolerate` queries nodes labeled `netperf=server` and `netperf=client`, collects their taints, and automatically adds matching tolerations to all pods. Disabled by default. Deduplicates against any manual `--toleration` keys.
+- `--toleration key` adds a toleration (with `Exists` operator and no effect, so it matches taints with any effect) for the given taint key to all netperf pods. Can be repeated.
+- `--auto-tolerate` queries the same nodes targeted by `--node-selector` (or worker nodes by default), collects their taints, and automatically adds matching tolerations to all pods. Disabled by default. Deduplicates against any manual `--toleration` keys.
 - `--tag` attaches labels to indexed results (OpenSearch, JSON, CSV) for filtering and comparing different configurations in dashboards. Can be repeated (e.g. `--tag baseline --tag cluster-a`).
 - `--csv` archives results in CSV files. Enabled by default in human-readable mode. Automatically disabled when `--json` or `--search` is used, unless `--csv` is explicitly passed.
-- `--search` OpenSearch URL for indexing results. When set, CSV generation is skipped unless `--csv` is explicitly passed.
+- `--search` OpenSearch URL for indexing results. When set, CSV generation is skipped unless `--csv` is explicitly passed. Basic auth is supported, but **do not embed credentials in the URL on shared systems** — command-line arguments are visible in the process list (`ps`) and shell history. Prefer a network path that does not require inline credentials (e.g. a proxy or an unauthenticated in-cluster endpoint).
 
 > *Note: On OpenShift, Prometheus is auto-discovered via the monitoring route. On non-OpenShift clusters, pass the Prometheus URL via `--prom`. If the OpenShift route is not reachable, it might be necessary to `port-forward` the service and pass the URL via `--prom`.*

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/client-go v0.35.2
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	kubevirt.io/api v1.2.2
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -132,5 +133,4 @@ require (
 	kubevirt.io/containerized-data-importer-api v1.61.1 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -19,48 +19,49 @@ const ltcyMetric = "usec"
 
 // Doc struct of the JSON document to be indexed
 type Doc struct {
-	UUID               string           `json:"uuid"`
-	Timestamp          time.Time        `json:"timestamp"`
-	HostNetwork        bool             `json:"hostNetwork"`
-	Driver             string           `json:"driver"`
-	Parallelism        int              `json:"parallelism"`
-	Profile            string           `json:"profile"`
-	Duration           int              `json:"duration"`
-	Service            bool             `json:"service"`
-	Local              bool             `json:"local"`
-	Virt               bool             `json:"virt"`
-	AcrossAZ           bool             `json:"acrossAZ"`
-	Samples            int              `json:"samples"`
-	Messagesize        int              `json:"messageSize"`
-	Burst              int              `json:"burst"`
-	Throughput         float64          `json:"throughput"`
-	Latency            float64          `json:"latency"`
-	TputMetric         string           `json:"tputMetric"`
-	LtcyMetric         string           `json:"ltcyMetric"`
-	TCPRetransmit      float64          `json:"tcpRetransmits"`
-	UDPLossPercent     float64          `json:"udpLossPercent"`
-	ToolVersion        string           `json:"toolVersion"`
-	ToolGitCommit      string           `json:"toolGitCommit"`
-	Metadata           result.Metadata  `json:"metadata"`
-	ServerNodeCPU      metrics.NodeCPU  `json:"serverCPU"`
+	UUID              string              `json:"uuid"`
+	Timestamp         time.Time           `json:"timestamp"`
+	HostNetwork       bool                `json:"hostNetwork"`
+	Driver            string              `json:"driver"`
+	Parallelism       int                 `json:"parallelism"`
+	Profile           string              `json:"profile"`
+	Duration          int                 `json:"duration"`
+	Service           bool                `json:"service"`
+	Local             bool                `json:"local"`
+	Virt              bool                `json:"virt"`
+	AcrossAZ          bool                `json:"acrossAZ"`
+	Samples           int                 `json:"samples"`
+	Messagesize       int                 `json:"messageSize"`
+	Burst             int                 `json:"burst"`
+	Throughput        metrics.JsonFloat64 `json:"throughput"`
+	Latency           metrics.JsonFloat64 `json:"latency"`
+	TputMetric        string              `json:"tputMetric"`
+	LtcyMetric        string              `json:"ltcyMetric"`
+	TCPRetransmit     metrics.JsonFloat64 `json:"tcpRetransmits"`
+	UDPLossPercent    metrics.JsonFloat64 `json:"udpLossPercent"`
+	ToolVersion       string              `json:"toolVersion"`
+	ToolGitCommit     string              `json:"toolGitCommit"`
+	Metadata          result.Metadata     `json:"metadata"`
+	ServerNodeCPU     metrics.NodeCPU     `json:"serverCPU"`
 	ServerCPUCollected bool             `json:"serverCPUCollected"`
-	ServerPodCPU       []metrics.PodCPU `json:"serverPods"`
-	ServerPodMem       []metrics.PodMem `json:"serverPodsMem"`
-	ClientNodeCPU      metrics.NodeCPU  `json:"clientCPU"`
+	ServerPodCPU      []metrics.PodCPU    `json:"serverPods"`
+	ServerPodMem      []metrics.PodMem    `json:"serverPodsMem"`
+	ClientNodeCPU     metrics.NodeCPU     `json:"clientCPU"`
 	ClientCPUCollected bool             `json:"clientCPUCollected"`
-	ClientPodCPU       []metrics.PodCPU `json:"clientPods"`
-	ClientPodMem       []metrics.PodMem `json:"clientPodsMem"`
-	Confidence         []float64        `json:"confidence"`
-	ServerNodeInfo     metrics.NodeInfo `json:"serverNodeInfo"`
-	ClientNodeInfo     metrics.NodeInfo `json:"clientNodeInfo"`
-	ServerVSwitchCpu   float64          `json:"serverVswtichCpu"`
-	ServerVSwitchMem   float64          `json:"serverVswitchMem"`
-	ClientVSwitchCpu   float64          `json:"clientVswtichCpu"`
-	ClientVSwiitchMem  float64          `json:"clientVswitchMem"`
-	ExternalServer     bool             `json:"externalServer"`
-	UdnInfo            string           `json:"udnInfo"`
-	BridgeInfo         string           `json:"bridgeInfo"`
-	SriovInfo          string           `json:"sriovInfo"`
+	ClientPodCPU      []metrics.PodCPU    `json:"clientPods"`
+	ClientPodMem      []metrics.PodMem    `json:"clientPodsMem"`
+	Confidence        []float64           `json:"confidence"`
+	ServerNodeInfo    metrics.NodeInfo    `json:"serverNodeInfo"`
+	ClientNodeInfo    metrics.NodeInfo    `json:"clientNodeInfo"`
+	ServerVSwitchCpu  metrics.JsonFloat64 `json:"serverVswtichCpu"`
+	ServerVSwitchMem  metrics.JsonFloat64 `json:"serverVswitchMem"`
+	ClientVSwitchCpu  metrics.JsonFloat64 `json:"clientVswtichCpu"`
+	ClientVSwiitchMem metrics.JsonFloat64 `json:"clientVswitchMem"`
+	ExternalServer    bool                `json:"externalServer"`
+	UdnInfo           string              `json:"udnInfo"`
+	BridgeInfo        string              `json:"bridgeInfo"`
+	SriovInfo         string              `json:"sriovInfo"`
+	Tags              []string            `json:"tags,omitempty"`
 	MacvlanInfo        string           `json:"macvlanInfo"`
 }
 
@@ -85,7 +86,7 @@ func Connect(url, index string, skip bool) (*indexers.Indexer, error) {
 }
 
 // BuildDocs returns the documents that need to be indexed or an error.
-func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
+func BuildDocs(sr result.ScenarioResults, uuid string, tags []string) ([]interface{}, error) {
 	time := time.Now().UTC()
 
 	var docs []interface{}
@@ -102,44 +103,45 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 		}
 		c := []float64{lo, hi}
 		d := Doc{
-			UUID:               uuid,
-			Timestamp:          time,
-			ToolVersion:        sr.Version,
-			ToolGitCommit:      sr.GitCommit,
-			Driver:             r.Driver,
-			HostNetwork:        r.HostNetwork,
-			Parallelism:        r.Parallelism,
-			Profile:            r.Profile,
-			Duration:           r.Duration,
-			Virt:               r.Virt,
-			Samples:            r.Samples,
-			Service:            r.Service,
+			UUID:              uuid,
+			Timestamp:         time,
+			ToolVersion:       sr.Version,
+			ToolGitCommit:     sr.GitCommit,
+			Driver:            r.Driver,
+			HostNetwork:       r.HostNetwork,
+			Parallelism:       r.Parallelism,
+			Profile:           r.Profile,
+			Duration:          r.Duration,
+			Virt:              r.Virt,
+			Samples:           r.Samples,
+			Service:           r.Service,
 			Local:              r.SameNode,
-			ExternalServer:     r.ExternalServer,
-			Messagesize:        r.MessageSize,
-			Burst:              r.Burst,
-			TputMetric:         r.Metric,
-			LtcyMetric:         ltcyMetric,
-			ServerNodeCPU:      r.ServerMetrics,
+			ExternalServer:    r.ExternalServer,
+			Messagesize:       r.MessageSize,
+			Burst:             r.Burst,
+			TputMetric:        r.Metric,
+			LtcyMetric:        ltcyMetric,
+			ServerNodeCPU:     r.ServerMetrics,
 			ServerCPUCollected: r.ServerCPUCollected,
-			ClientNodeCPU:      r.ClientMetrics,
+			ClientNodeCPU:     r.ClientMetrics,
 			ClientCPUCollected: r.ClientCPUCollected,
-			ServerPodCPU:       r.ServerPodCPU.Results,
-			ServerPodMem:       r.ServerPodMem.MemResults,
-			ClientPodMem:       r.ClientPodMem.MemResults,
-			ClientPodCPU:       r.ClientPodCPU.Results,
-			ClientVSwitchCpu:   r.ClientMetrics.VSwitchCPU,
-			ClientVSwiitchMem:  r.ClientMetrics.VSwitchMem,
-			ServerVSwitchCpu:   r.ServerMetrics.VSwitchCPU,
-			ServerVSwitchMem:   r.ServerMetrics.VSwitchMem,
-			Metadata:           sr.Metadata,
-			AcrossAZ:           r.AcrossAZ,
-			Confidence:         c,
-			ClientNodeInfo:     r.ClientNodeInfo,
-			ServerNodeInfo:     r.ServerNodeInfo,
-			UdnInfo:            r.UdnInfo,
-			BridgeInfo:         r.BridgeInfo,
-			SriovInfo:          r.SriovInfo,
+			ServerPodCPU:      r.ServerPodCPU.Results,
+			ServerPodMem:      r.ServerPodMem.MemResults,
+			ClientPodMem:      r.ClientPodMem.MemResults,
+			ClientPodCPU:      r.ClientPodCPU.Results,
+			ClientVSwitchCpu:  r.ClientMetrics.VSwitchCPU,
+			ClientVSwiitchMem: r.ClientMetrics.VSwitchMem,
+			ServerVSwitchCpu:  r.ServerMetrics.VSwitchCPU,
+			ServerVSwitchMem:  r.ServerMetrics.VSwitchMem,
+			Metadata:          sr.Metadata,
+			AcrossAZ:          r.AcrossAZ,
+			Confidence:        c,
+			ClientNodeInfo:    r.ClientNodeInfo,
+			ServerNodeInfo:    r.ServerNodeInfo,
+			UdnInfo:           r.UdnInfo,
+			BridgeInfo:        r.BridgeInfo,
+			SriovInfo:         r.SriovInfo,
+			Tags:              tags,
 			MacvlanInfo:        r.MacvlanInfo,
 		}
 		UDPLossPercent, e := result.Average(r.LossSummary)
@@ -147,28 +149,28 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 			logging.Warn("Unable to process udp loss, setting value to zero")
 			d.UDPLossPercent = 0
 		} else {
-			d.UDPLossPercent = UDPLossPercent
+			d.UDPLossPercent = metrics.JsonFloat64(UDPLossPercent)
 		}
 		TCPRetransmit, e := result.Average(r.RetransmitSummary)
 		if e != nil {
 			logging.Warn("Unable to process tcp retransmits, setting value to zero")
 			d.TCPRetransmit = 0
 		} else {
-			d.TCPRetransmit = TCPRetransmit
+			d.TCPRetransmit = metrics.JsonFloat64(TCPRetransmit)
 		}
 		Throughput, e := result.Average(r.ThroughputSummary)
 		if e != nil {
 			logging.Warn("Unable to process throughput, setting value to zero")
 			d.Throughput = 0
 		} else {
-			d.Throughput = Throughput
+			d.Throughput = metrics.JsonFloat64(Throughput)
 		}
 		Latency, e := result.Average(r.LatencySummary)
 		if e != nil {
 			logging.Warn("Unable to process latency, setting value to zero")
 			d.Latency = 0
 		} else {
-			d.Latency = Latency
+			d.Latency = metrics.JsonFloat64(Latency)
 		}
 		docs = append(docs, d)
 	}
@@ -178,6 +180,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 // Common csv header fields.
 func commonCsvHeaderFields() []string {
 	return []string{
+		"Tags",
 		"Driver",
 		"Profile",
 		"Same node",
@@ -200,12 +203,13 @@ func commonCsvHeaderFields() []string {
 }
 
 // Common csv data fields.
-func commonCsvDataFields(row result.Data) []string {
+func commonCsvDataFields(row result.Data, tags []string) []string {
 	var lo, hi float64
 	if row.Samples > 1 {
 		_, lo, hi = result.ConfidenceInterval(row.ThroughputSummary, 0.95)
 	}
 	return []string{
+		strings.Join(tags, ";"),
 		fmt.Sprint(row.Driver),
 		fmt.Sprint(row.Profile),
 		fmt.Sprint(row.SameNode),
@@ -228,11 +232,11 @@ func commonCsvDataFields(row result.Data) []string {
 }
 
 // Writes all the mertics to the archive.
-func writeArchive(vswitch, cpuarchive, podarchive, podmemarchive *csv.Writer, role string, row result.Data, podResults []metrics.PodCPU, podMem []metrics.PodMem) error {
+func writeArchive(vswitch, cpuarchive, podarchive, podmemarchive *csv.Writer, role string, row result.Data, podResults []metrics.PodCPU, podMem []metrics.PodMem, tags []string) error {
 	roleFieldData := []string{role}
 	for _, pod := range podResults {
 		if err := podarchive.Write(append(append(roleFieldData,
-			commonCsvDataFields(row)...),
+			commonCsvDataFields(row, tags)...),
 			pod.Name,
 			fmt.Sprintf("%f", pod.Value),
 		)); err != nil {
@@ -241,7 +245,7 @@ func writeArchive(vswitch, cpuarchive, podarchive, podmemarchive *csv.Writer, ro
 	}
 	for _, pod := range podMem {
 		if err := podmemarchive.Write(append(append(roleFieldData,
-			commonCsvDataFields(row)...),
+			commonCsvDataFields(row, tags)...),
 			pod.Name,
 			fmt.Sprintf("%f", pod.Value),
 		)); err != nil {
@@ -254,13 +258,13 @@ func writeArchive(vswitch, cpuarchive, podarchive, podmemarchive *csv.Writer, ro
 		cpu = row.ServerMetrics
 	}
 	if err := vswitch.Write(append(append(roleFieldData,
-		commonCsvDataFields(row)...),
+		commonCsvDataFields(row, tags)...),
 		fmt.Sprintf("%f", cpu.VSwitchCPU),
 		fmt.Sprintf("%f", cpu.VSwitchMem))); err != nil {
 		return fmt.Errorf("failed to write archive to file")
 	}
 	if err := cpuarchive.Write(append(append(roleFieldData,
-		commonCsvDataFields(row)...),
+		commonCsvDataFields(row, tags)...),
 		fmt.Sprintf("%f", cpu.Idle),
 		fmt.Sprintf("%f", cpu.User),
 		fmt.Sprintf("%f", cpu.System),
@@ -357,10 +361,10 @@ func WritePromCSVResult(r result.ScenarioResults) error {
 		return fmt.Errorf("failed to write vswitch archive to file")
 	}
 	for _, row := range r.Results {
-		if err := writeArchive(vswitch, cpuarchive, podarchive, podmemarchive, "Client", row, row.ClientPodCPU.Results, row.ClientPodMem.MemResults); err != nil {
+		if err := writeArchive(vswitch, cpuarchive, podarchive, podmemarchive, "Client", row, row.ClientPodCPU.Results, row.ClientPodMem.MemResults, r.Tags); err != nil {
 			return err
 		}
-		if err := writeArchive(vswitch, cpuarchive, podarchive, podmemarchive, "Server", row, row.ServerPodCPU.Results, row.ServerPodMem.MemResults); err != nil {
+		if err := writeArchive(vswitch, cpuarchive, podarchive, podmemarchive, "Server", row, row.ServerPodCPU.Results, row.ServerPodMem.MemResults, r.Tags); err != nil {
 			return err
 		}
 	}
@@ -390,7 +394,7 @@ func WriteSpecificCSV(r result.ScenarioResults) error {
 		if strings.Contains(row.Profile, "UDP_STREAM") {
 			loss, _ := result.Average(row.LossSummary)
 			header := []string{"UDP Percent Loss"}
-			data := append(header, commonCsvDataFields(row)...)
+			data := append(header, commonCsvDataFields(row, r.Tags)...)
 			iperfdata = append(data, fmt.Sprintf("%f", loss))
 			if err := archive.Write(iperfdata); err != nil {
 				return fmt.Errorf("failed to write result archive to file")
@@ -399,7 +403,7 @@ func WriteSpecificCSV(r result.ScenarioResults) error {
 		if strings.Contains(row.Profile, "TCP_STREAM") {
 			rt, _ := result.Average(row.RetransmitSummary)
 			header := []string{"TCP Retransmissions"}
-			data := append(header, commonCsvDataFields(row)...)
+			data := append(header, commonCsvDataFields(row, r.Tags)...)
 			iperfdata = append(data, fmt.Sprintf("%f", rt))
 			if err := archive.Write(iperfdata); err != nil {
 				return fmt.Errorf("failed to write result archive to file")
@@ -411,7 +415,7 @@ func WriteSpecificCSV(r result.ScenarioResults) error {
 
 // WriteJSONResult sends the results as JSON to stdout
 func WriteJSONResult(r result.ScenarioResults) error {
-	docs, err := BuildDocs(r, "k8s-netperf")
+	docs, err := BuildDocs(r, "k8s-netperf", r.Tags)
 	if err != nil {
 		return err
 	}
@@ -451,7 +455,7 @@ func WriteCSVResult(r result.ScenarioResults) error {
 	for _, row := range r.Results {
 		avg, _ := result.Average(row.ThroughputSummary)
 		lavg, _ := result.Average(row.LatencySummary)
-		data := append(commonCsvDataFields(row),
+		data := append(commonCsvDataFields(row, r.Tags),
 			fmt.Sprintf("%f", avg),
 			row.Metric,
 			fmt.Sprint(lavg),

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -108,6 +108,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string, tags []string) ([]interfa
 			ToolVersion:       sr.Version,
 			ToolGitCommit:     sr.GitCommit,
 			Driver:            r.Driver,
+			Local:             r.SameNode,
 			HostNetwork:       r.HostNetwork,
 			Parallelism:       r.Parallelism,
 			Profile:           r.Profile,

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -19,50 +19,50 @@ const ltcyMetric = "usec"
 
 // Doc struct of the JSON document to be indexed
 type Doc struct {
-	UUID              string              `json:"uuid"`
-	Timestamp         time.Time           `json:"timestamp"`
-	HostNetwork       bool                `json:"hostNetwork"`
-	Driver            string              `json:"driver"`
-	Parallelism       int                 `json:"parallelism"`
-	Profile           string              `json:"profile"`
-	Duration          int                 `json:"duration"`
-	Service           bool                `json:"service"`
-	Local             bool                `json:"local"`
-	Virt              bool                `json:"virt"`
-	AcrossAZ          bool                `json:"acrossAZ"`
-	Samples           int                 `json:"samples"`
-	Messagesize       int                 `json:"messageSize"`
-	Burst             int                 `json:"burst"`
-	Throughput        metrics.JsonFloat64 `json:"throughput"`
-	Latency           metrics.JsonFloat64 `json:"latency"`
-	TputMetric        string              `json:"tputMetric"`
-	LtcyMetric        string              `json:"ltcyMetric"`
-	TCPRetransmit     metrics.JsonFloat64 `json:"tcpRetransmits"`
-	UDPLossPercent    metrics.JsonFloat64 `json:"udpLossPercent"`
-	ToolVersion       string              `json:"toolVersion"`
-	ToolGitCommit     string              `json:"toolGitCommit"`
-	Metadata          result.Metadata     `json:"metadata"`
-	ServerNodeCPU     metrics.NodeCPU     `json:"serverCPU"`
-	ServerCPUCollected bool             `json:"serverCPUCollected"`
-	ServerPodCPU      []metrics.PodCPU    `json:"serverPods"`
-	ServerPodMem      []metrics.PodMem    `json:"serverPodsMem"`
-	ClientNodeCPU     metrics.NodeCPU     `json:"clientCPU"`
-	ClientCPUCollected bool             `json:"clientCPUCollected"`
-	ClientPodCPU      []metrics.PodCPU    `json:"clientPods"`
-	ClientPodMem      []metrics.PodMem    `json:"clientPodsMem"`
-	Confidence        []float64           `json:"confidence"`
-	ServerNodeInfo    metrics.NodeInfo    `json:"serverNodeInfo"`
-	ClientNodeInfo    metrics.NodeInfo    `json:"clientNodeInfo"`
-	ServerVSwitchCpu  metrics.JsonFloat64 `json:"serverVswtichCpu"`
-	ServerVSwitchMem  metrics.JsonFloat64 `json:"serverVswitchMem"`
-	ClientVSwitchCpu  metrics.JsonFloat64 `json:"clientVswtichCpu"`
-	ClientVSwiitchMem metrics.JsonFloat64 `json:"clientVswitchMem"`
-	ExternalServer    bool                `json:"externalServer"`
-	UdnInfo           string              `json:"udnInfo"`
-	BridgeInfo        string              `json:"bridgeInfo"`
-	SriovInfo         string              `json:"sriovInfo"`
-	Tags              []string            `json:"tags,omitempty"`
-	MacvlanInfo        string           `json:"macvlanInfo"`
+	UUID               string              `json:"uuid"`
+	Timestamp          time.Time           `json:"timestamp"`
+	HostNetwork        bool                `json:"hostNetwork"`
+	Driver             string              `json:"driver"`
+	Parallelism        int                 `json:"parallelism"`
+	Profile            string              `json:"profile"`
+	Duration           int                 `json:"duration"`
+	Service            bool                `json:"service"`
+	Local              bool                `json:"local"`
+	Virt               bool                `json:"virt"`
+	AcrossAZ           bool                `json:"acrossAZ"`
+	Samples            int                 `json:"samples"`
+	Messagesize        int                 `json:"messageSize"`
+	Burst              int                 `json:"burst"`
+	Throughput         metrics.JsonFloat64 `json:"throughput"`
+	Latency            metrics.JsonFloat64 `json:"latency"`
+	TputMetric         string              `json:"tputMetric"`
+	LtcyMetric         string              `json:"ltcyMetric"`
+	TCPRetransmit      metrics.JsonFloat64 `json:"tcpRetransmits"`
+	UDPLossPercent     metrics.JsonFloat64 `json:"udpLossPercent"`
+	ToolVersion        string              `json:"toolVersion"`
+	ToolGitCommit      string              `json:"toolGitCommit"`
+	Metadata           result.Metadata     `json:"metadata"`
+	ServerNodeCPU      metrics.NodeCPU     `json:"serverCPU"`
+	ServerCPUCollected bool                `json:"serverCPUCollected"`
+	ServerPodCPU       []metrics.PodCPU    `json:"serverPods"`
+	ServerPodMem       []metrics.PodMem    `json:"serverPodsMem"`
+	ClientNodeCPU      metrics.NodeCPU     `json:"clientCPU"`
+	ClientCPUCollected bool                `json:"clientCPUCollected"`
+	ClientPodCPU       []metrics.PodCPU    `json:"clientPods"`
+	ClientPodMem       []metrics.PodMem    `json:"clientPodsMem"`
+	Confidence         []float64           `json:"confidence"`
+	ServerNodeInfo     metrics.NodeInfo    `json:"serverNodeInfo"`
+	ClientNodeInfo     metrics.NodeInfo    `json:"clientNodeInfo"`
+	ServerVSwitchCpu   metrics.JsonFloat64 `json:"serverVswtichCpu"`
+	ServerVSwitchMem   metrics.JsonFloat64 `json:"serverVswitchMem"`
+	ClientVSwitchCpu   metrics.JsonFloat64 `json:"clientVswtichCpu"`
+	ClientVSwiitchMem  metrics.JsonFloat64 `json:"clientVswitchMem"`
+	ExternalServer     bool                `json:"externalServer"`
+	UdnInfo            string              `json:"udnInfo"`
+	BridgeInfo         string              `json:"bridgeInfo"`
+	SriovInfo          string              `json:"sriovInfo"`
+	Tags               []string            `json:"tags,omitempty"`
+	MacvlanInfo        string              `json:"macvlanInfo"`
 }
 
 // Connect returns a client connected to the desired cluster.
@@ -87,8 +87,6 @@ func Connect(url, index string, skip bool) (*indexers.Indexer, error) {
 
 // BuildDocs returns the documents that need to be indexed or an error.
 func BuildDocs(sr result.ScenarioResults, uuid string, tags []string) ([]interface{}, error) {
-	time := time.Now().UTC()
-
 	var docs []interface{}
 	if len(sr.Results) < 1 {
 		return nil, fmt.Errorf("no result documents")
@@ -103,46 +101,45 @@ func BuildDocs(sr result.ScenarioResults, uuid string, tags []string) ([]interfa
 		}
 		c := []float64{lo, hi}
 		d := Doc{
-			UUID:              uuid,
-			Timestamp:         time,
-			ToolVersion:       sr.Version,
-			ToolGitCommit:     sr.GitCommit,
-			Driver:            r.Driver,
-			Local:             r.SameNode,
-			HostNetwork:       r.HostNetwork,
-			Parallelism:       r.Parallelism,
-			Profile:           r.Profile,
-			Duration:          r.Duration,
-			Virt:              r.Virt,
-			Samples:           r.Samples,
-			Service:           r.Service,
+			UUID:               uuid,
+			Timestamp:          time.Now().UTC(),
+			ToolVersion:        sr.Version,
+			ToolGitCommit:      sr.GitCommit,
+			Driver:             r.Driver,
+			HostNetwork:        r.HostNetwork,
+			Parallelism:        r.Parallelism,
+			Profile:            r.Profile,
+			Duration:           r.Duration,
+			Virt:               r.Virt,
+			Samples:            r.Samples,
+			Service:            r.Service,
 			Local:              r.SameNode,
-			ExternalServer:    r.ExternalServer,
-			Messagesize:       r.MessageSize,
-			Burst:             r.Burst,
-			TputMetric:        r.Metric,
-			LtcyMetric:        ltcyMetric,
-			ServerNodeCPU:     r.ServerMetrics,
+			ExternalServer:     r.ExternalServer,
+			Messagesize:        r.MessageSize,
+			Burst:              r.Burst,
+			TputMetric:         r.Metric,
+			LtcyMetric:         ltcyMetric,
+			ServerNodeCPU:      r.ServerMetrics,
 			ServerCPUCollected: r.ServerCPUCollected,
-			ClientNodeCPU:     r.ClientMetrics,
+			ClientNodeCPU:      r.ClientMetrics,
 			ClientCPUCollected: r.ClientCPUCollected,
-			ServerPodCPU:      r.ServerPodCPU.Results,
-			ServerPodMem:      r.ServerPodMem.MemResults,
-			ClientPodMem:      r.ClientPodMem.MemResults,
-			ClientPodCPU:      r.ClientPodCPU.Results,
-			ClientVSwitchCpu:  r.ClientMetrics.VSwitchCPU,
-			ClientVSwiitchMem: r.ClientMetrics.VSwitchMem,
-			ServerVSwitchCpu:  r.ServerMetrics.VSwitchCPU,
-			ServerVSwitchMem:  r.ServerMetrics.VSwitchMem,
-			Metadata:          sr.Metadata,
-			AcrossAZ:          r.AcrossAZ,
-			Confidence:        c,
-			ClientNodeInfo:    r.ClientNodeInfo,
-			ServerNodeInfo:    r.ServerNodeInfo,
-			UdnInfo:           r.UdnInfo,
-			BridgeInfo:        r.BridgeInfo,
-			SriovInfo:         r.SriovInfo,
-			Tags:              tags,
+			ServerPodCPU:       r.ServerPodCPU.Results,
+			ServerPodMem:       r.ServerPodMem.MemResults,
+			ClientPodMem:       r.ClientPodMem.MemResults,
+			ClientPodCPU:       r.ClientPodCPU.Results,
+			ClientVSwitchCpu:   r.ClientMetrics.VSwitchCPU,
+			ClientVSwiitchMem:  r.ClientMetrics.VSwitchMem,
+			ServerVSwitchCpu:   r.ServerMetrics.VSwitchCPU,
+			ServerVSwitchMem:   r.ServerMetrics.VSwitchMem,
+			Metadata:           sr.Metadata,
+			AcrossAZ:           r.AcrossAZ,
+			Confidence:         c,
+			ClientNodeInfo:     r.ClientNodeInfo,
+			ServerNodeInfo:     r.ServerNodeInfo,
+			UdnInfo:            r.UdnInfo,
+			BridgeInfo:         r.BridgeInfo,
+			SriovInfo:          r.SriovInfo,
+			Tags:               tags,
 			MacvlanInfo:        r.MacvlanInfo,
 		}
 		UDPLossPercent, e := result.Average(r.LossSummary)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -19,7 +19,7 @@ func TestBuildDocsMapsCPUCollectionFlags(t *testing.T) {
 				RetransmitSummary:  []float64{0},
 			},
 		},
-	}, "test-uuid")
+	}, "test-uuid", nil)
 	if err != nil {
 		t.Fatalf("BuildDocs returned unexpected error: %v", err)
 	}

--- a/pkg/archive/metadata_test.go
+++ b/pkg/archive/metadata_test.go
@@ -30,7 +30,7 @@ func TestBuildDocsArchivesFullClusterMetadata(t *testing.T) {
 				RetransmitSummary: []float64{0},
 			},
 		},
-	}, "test-uuid")
+	}, "test-uuid", nil)
 	if err != nil {
 		t.Fatalf("BuildDocs returned unexpected error: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestBuildDocsArchivesResultBooleans(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			docs, err := BuildDocs(result.ScenarioResults{
 				Results: []result.Data{tt.result},
-			}, "test-uuid")
+			}, "test-uuid", nil)
 			if err != nil {
 				t.Fatalf("BuildDocs returned unexpected error: %v", err)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,10 @@ type PerfScenarios struct {
 	HostNetworkOnly     bool
 	ExternalServer      bool
 	Privileged          bool
+	Namespace           string
+	NamespaceFile       string
+	NodeSelectors       map[string]string
+	Tolerations         []apiv1.Toleration
 	Configs             []Config
 	Pod                 bool
 	VM                  bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ type PerfScenarios struct {
 	Privileged          bool
 	Namespace           string
 	NamespaceFile       string
+	RunID               string
 	NodeSelectors       map[string]string
 	Tolerations         []apiv1.Toleration
 	Configs             []Config

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/config"
 	log "github.com/cloud-bulldozer/k8s-netperf/pkg/logging"
@@ -40,6 +43,7 @@ type DeploymentParams struct {
 	PodAffinity        corev1.PodAffinity
 	PodAntiAffinity    corev1.PodAntiAffinity
 	NodeAffinity       corev1.NodeAffinity
+	Tolerations        []corev1.Toleration
 	Port               int
 	NetworkAnnotations map[string]string
 	ResourceRequests   corev1.ResourceList
@@ -62,7 +66,17 @@ type PodNetworksData struct {
 }
 
 const sa string = "netperf"
-const namespace string = "netperf"
+
+// DefaultNamespace is the default namespace used for netperf resources
+const DefaultNamespace = "netperf"
+
+// Package-level variable that can be overridden via SetNamespace
+var namespace = DefaultNamespace
+
+// SetNamespace overrides the namespace used for all netperf resources
+func SetNamespace(ns string) {
+	namespace = ns
+}
 
 // NetperfServerCtlPort control port for the service
 const NetperfServerCtlPort = 12865
@@ -166,6 +180,37 @@ func buildSriovNetworkAnnotations() map[string]string {
 	return annotations
 }
 
+// ReadNamespaceFromFile reads a namespace YAML file and returns the namespace name.
+func ReadNamespaceFromFile(filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("unable to read namespace file %s: %v", filePath, err)
+	}
+	var ns corev1.Namespace
+	if err := yaml.Unmarshal(data, &ns); err != nil {
+		return "", fmt.Errorf("unable to parse namespace file %s: %v", filePath, err)
+	}
+	if ns.Name == "" {
+		return "", fmt.Errorf("namespace file %s must have metadata.name set", filePath)
+	}
+	return ns.Name, nil
+}
+
+// createNamespaceFromFile reads a namespace YAML file and creates the namespace.
+func createNamespaceFromFile(client *kubernetes.Clientset, filePath string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("unable to read namespace file %s: %v", filePath, err)
+	}
+	var ns corev1.Namespace
+	if err := yaml.Unmarshal(data, &ns); err != nil {
+		return fmt.Errorf("unable to parse namespace file %s: %v", filePath, err)
+	}
+	log.Infof("🔨 Creating namespace %s from file: %s", ns.Name, filePath)
+	_, err = client.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+	return err
+}
+
 // buildMacvlanNetworkAnnotations creates the network annotations for Multus CNI MACVLAN networks
 func buildMacvlanNetworkAnnotations() map[string]string {
 	annotations := make(map[string]string)
@@ -237,18 +282,22 @@ func ExtractMacvlanIp(pod corev1.Pod) (string, error) {
 }
 
 // BuildInfra will create the infra for the SUT
-func BuildInfra(client *kubernetes.Clientset, udn bool) error {
+func BuildInfra(client *kubernetes.Clientset, udn bool, namespaceFile string) error {
 	_, err := client.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 	if err == nil {
 		log.Infof("♻️ Namespace already exists, reusing it")
 	} else {
-		log.Infof("🔨 Creating namespace: %s", namespace)
-		if udn {
-			_, err = client.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace,
-				Labels: map[string]string{"k8s.ovn.org/primary-user-defined-network": ""}}}, metav1.CreateOptions{})
+		if namespaceFile != "" {
+			err = createNamespaceFromFile(client, namespaceFile)
 		} else {
-			_, err = client.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace,
-				Labels: map[string]string{"netperf": "test-namespace"}}}, metav1.CreateOptions{})
+			log.Infof("🔨 Creating namespace: %s", namespace)
+			if udn {
+				_, err = client.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace,
+					Labels: map[string]string{"k8s.ovn.org/primary-user-defined-network": ""}}}, metav1.CreateOptions{})
+			} else {
+				_, err = client.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace,
+					Labels: map[string]string{"netperf": "test-namespace"}}}, metav1.CreateOptions{})
+			}
 		}
 		if err != nil {
 			return fmt.Errorf("😥 Unable to create namespace: %v", err)
@@ -264,31 +313,38 @@ func BuildInfra(client *kubernetes.Clientset, udn bool) error {
 			return fmt.Errorf("😥 Unable to create service account: %v", err)
 		}
 	}
-	rBinding := &v1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      sa,
-			Namespace: namespace,
-		},
-		RoleRef: v1.RoleRef{
-			Kind: "ClusterRole",
-			Name: "system:openshift:scc:hostnetwork",
-		},
-		Subjects: []v1.Subject{
-			{
-				Namespace: namespace,
-				Name:      sa,
-				Kind:      "ServiceAccount",
-			},
-		},
-	}
-	_, err = client.RbacV1().RoleBindings(namespace).Get(context.TODO(), sa, metav1.GetOptions{})
+	// Only create the hostnetwork SCC role binding if the OpenShift ClusterRole exists
+	const sccClusterRole = "system:openshift:scc:hostnetwork"
+	_, err = client.RbacV1().ClusterRoles().Get(context.TODO(), sccClusterRole, metav1.GetOptions{})
 	if err == nil {
-		log.Infof("♻️ Role binding already exists, reusing it")
-	} else {
-		_, err = client.RbacV1().RoleBindings(namespace).Create(context.TODO(), rBinding, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("😥 Unable to create role-binding: %v", err)
+		rBinding := &v1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sa,
+				Namespace: namespace,
+			},
+			RoleRef: v1.RoleRef{
+				Kind: "ClusterRole",
+				Name: sccClusterRole,
+			},
+			Subjects: []v1.Subject{
+				{
+					Namespace: namespace,
+					Name:      sa,
+					Kind:      "ServiceAccount",
+				},
+			},
 		}
+		_, err = client.RbacV1().RoleBindings(namespace).Get(context.TODO(), sa, metav1.GetOptions{})
+		if err == nil {
+			log.Infof("♻️ Role binding already exists, reusing it")
+		} else {
+			_, err = client.RbacV1().RoleBindings(namespace).Create(context.TODO(), rBinding, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("😥 Unable to create role-binding: %v", err)
+			}
+		}
+	} else {
+		log.Debug("Skipping OpenShift SCC role binding (non-OpenShift cluster)")
 	}
 	return nil
 }
@@ -606,6 +662,19 @@ func DestroySriovResources(dyn *dynamic.DynamicClient) error {
 	return nil
 }
 
+// NodeLabelSelector builds a label selector string from NodeSelectors,
+// falling back to the default worker node selector when none are provided.
+func NodeLabelSelector(nodeSelectors map[string]string) string {
+	if len(nodeSelectors) > 0 {
+		parts := make([]string, 0, len(nodeSelectors))
+		for key, value := range nodeSelectors {
+			parts = append(parts, key+"="+value)
+		}
+		return strings.Join(parts, ",")
+	}
+	return "node-role.kubernetes.io/worker="
+}
+
 // BuildSUT Build the k8s env to run network performance tests
 func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	var netperfDataPorts []int32
@@ -620,15 +689,27 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		}
 	}
 
-	// Schedule pods to nodes with role worker=, but not nodes with infra= and workload=
+	// Build node selector expressions for pod scheduling.
+	// When --node-selector is provided, use those selectors instead of the defaults.
+	var matchExpressions []corev1.NodeSelectorRequirement
+	if len(s.NodeSelectors) > 0 {
+		for key, value := range s.NodeSelectors {
+			matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
+				Key: key, Operator: corev1.NodeSelectorOpIn, Values: []string{value},
+			})
+		}
+	} else {
+		// Default: schedule on worker nodes, exclude infra and workload nodes
+		matchExpressions = []corev1.NodeSelectorRequirement{
+			{Key: "node-role.kubernetes.io/worker", Operator: corev1.NodeSelectorOpIn, Values: []string{""}},
+			{Key: "node-role.kubernetes.io/infra", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
+			{Key: "node-role.kubernetes.io/workload", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
+		}
+	}
 	workerNodeSelectorExpression := &corev1.NodeSelector{
 		NodeSelectorTerms: []corev1.NodeSelectorTerm{
 			{
-				MatchExpressions: []corev1.NodeSelectorRequirement{
-					{Key: "node-role.kubernetes.io/worker", Operator: corev1.NodeSelectorOpIn, Values: []string{""}},
-					{Key: "node-role.kubernetes.io/infra", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
-					{Key: "node-role.kubernetes.io/workload", Operator: corev1.NodeSelectorOpNotIn, Values: []string{""}},
-				},
+				MatchExpressions: matchExpressions,
 			},
 		},
 	}
@@ -647,7 +728,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		}
 		cdp := DeploymentParams{
 			Name:               "client",
-			Namespace:          "netperf",
+			Namespace:          namespace,
 			Replicas:           1,
 			Image:              k8sNetperfImage,
 			Labels:             map[string]string{"role": clientRole},
@@ -656,6 +737,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			NetworkAnnotations: networkAnnotations,
 			ResourceRequests:   sriovResources,
 			Privileged:         s.Privileged,
+			Tolerations:        s.Tolerations,
 		}
 
 		cdp.NodeAffinity = corev1.NodeAffinity{
@@ -675,7 +757,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	}
 	// Check if nodes have the zone label to keep the netperf test
 	// in the same AZ/Zone versus across AZ/Zone
-	z, zones, err := GetZone(client)
+	z, zones, err := GetZone(client, NodeLabelSelector(s.NodeSelectors))
 	if err != nil {
 		log.Warn(err)
 	}
@@ -699,8 +781,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		}
 	}
 
-	// Get node count
-	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker=,node-role.kubernetes.io/infra!="})
+	// Get node count using the same selector logic as pod scheduling
+	nodeCountSelector := NodeLabelSelector(s.NodeSelectors)
+	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nodeCountSelector})
 	if err != nil {
 		return err
 	}
@@ -736,7 +819,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		}
 		cdp := DeploymentParams{
 			Name:               "client",
-			Namespace:          "netperf",
+			Namespace:          namespace,
 			Replicas:           1,
 			HostNetwork:        s.HostNetwork,
 			Image:              k8sNetperfImage,
@@ -746,6 +829,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			NetworkAnnotations: networkAnnotations,
 			ResourceRequests:   sriovResources,
 			Privileged:         s.Privileged,
+			Tolerations:        s.Tolerations,
 		}
 		if z != "" && numNodes > 1 {
 			cdp.NodeAffinity = corev1.NodeAffinity{
@@ -787,7 +871,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			// Create iperf service
 			iperfSVC := ServiceParams{
 				Name:      "iperf-service",
-				Namespace: "netperf",
+				Namespace: namespace,
 				Labels:    map[string]string{"role": serverRole},
 				CtlPort:   IperfServerCtlPort,
 				DataPorts: []int32{IperfServerDataPort},
@@ -801,7 +885,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			// Create iperf VM service
 			iperfSVC := ServiceParams{
 				Name:      "iperf-vm-service",
-				Namespace: "netperf",
+				Namespace: namespace,
 				Labels:    map[string]string{"role": vmServerRole},
 				CtlPort:   IperfServerCtlPort,
 				DataPorts: []int32{IperfVmServerDataPort},
@@ -818,7 +902,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			// Create uperf service
 			uperfSVC := ServiceParams{
 				Name:      "uperf-service",
-				Namespace: "netperf",
+				Namespace: namespace,
 				Labels:    map[string]string{"role": serverRole},
 				CtlPort:   UperfServerCtlPort,
 				DataPorts: []int32{UperfServerDataPort},
@@ -843,7 +927,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		if s.VM {
 			uperfSVC := ServiceParams{
 				Name:      "uperf-vm-service",
-				Namespace: "netperf",
+				Namespace: namespace,
 				Labels:    map[string]string{"role": vmServerRole},
 				CtlPort:   UperfServerCtlPort,
 				DataPorts: []int32{UperfVmServerDataPort},
@@ -875,7 +959,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			}
 			netperfSVC := ServiceParams{
 				Name:      "netperf-service",
-				Namespace: "netperf",
+				Namespace: namespace,
 				Labels:    map[string]string{"role": serverRole},
 				CtlPort:   NetperfServerCtlPort,
 				DataPorts: netperfDataPorts,
@@ -892,7 +976,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			}
 			netperfSVC := ServiceParams{
 				Name:      "netperf-vm-service",
-				Namespace: "netperf",
+				Namespace: namespace,
 				Labels:    map[string]string{"role": vmServerRole},
 				CtlPort:   NetperfServerCtlPort,
 				DataPorts: netperfVmDataPorts,
@@ -917,7 +1001,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	}
 	cdpAcross := DeploymentParams{
 		Name:               "client-across",
-		Namespace:          "netperf",
+		Namespace:          namespace,
 		Replicas:           1,
 		Image:              k8sNetperfImage,
 		Labels:             map[string]string{"role": clientAcrossRole},
@@ -926,6 +1010,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		NetworkAnnotations: networkAnnotations,
 		ResourceRequests:   sriovResources,
 		Privileged:         s.Privileged,
+		Tolerations:        s.Tolerations,
 	}
 	cdpAcross.PodAntiAffinity = corev1.PodAntiAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: clientRoleAffinity,
@@ -933,7 +1018,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 
 	cdpHostAcross := DeploymentParams{
 		Name:        "client-host",
-		Namespace:   "netperf",
+		Namespace:   namespace,
 		Replicas:    1,
 		HostNetwork: true,
 		Image:       k8sNetperfImage,
@@ -941,6 +1026,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		Commands:    [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 		Port:        NetperfServerCtlPort,
 		Privileged:  s.Privileged,
+		Tolerations: s.Tolerations,
 	}
 	if z != "" {
 		if numNodes > 1 {
@@ -1064,7 +1150,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 
 	sdpHost := DeploymentParams{
 		Name:        "server-host",
-		Namespace:   "netperf",
+		Namespace:   namespace,
 		Replicas:    1,
 		HostNetwork: true,
 		Image:       k8sNetperfImage,
@@ -1072,11 +1158,12 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		Commands:    dpCommands,
 		Port:        NetperfServerCtlPort,
 		Privileged:  s.Privileged,
+		Tolerations: s.Tolerations,
 	}
 	// Start netperf server
 	sdp := DeploymentParams{
 		Name:               "server",
-		Namespace:          "netperf",
+		Namespace:          namespace,
 		Replicas:           1,
 		Image:              k8sNetperfImage,
 		Labels:             map[string]string{"role": serverRole},
@@ -1085,6 +1172,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		NetworkAnnotations: networkAnnotations,
 		ResourceRequests:   sriovResources,
 		Privileged:         s.Privileged,
+		Tolerations:        s.Tolerations,
 	}
 	if s.NodeLocal {
 		sdp.PodAffinity = corev1.PodAffinity{
@@ -1469,11 +1557,11 @@ func waitForNamespaceDelete(c *kubernetes.Clientset, nsName string) error {
 
 // GetZone will determine if we have a multiAZ/Zone cloud.
 // returns string of the zone, int of the node count in that zone, error if encountered a problem.
-func GetZone(c *kubernetes.Clientset) (string, map[string]int, error) {
+func GetZone(c *kubernetes.Clientset, nodeSelector string) (string, map[string]int, error) {
 	zones := map[string]int{}
 	zone := ""
 	lz := ""
-	n, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker="})
+	n, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nodeSelector})
 	if err != nil {
 		return "", zones, fmt.Errorf("unable to query nodes: %v", err)
 	}
@@ -1527,12 +1615,18 @@ func CreateDeployment(dp DeploymentParams, client *kubernetes.Clientset) (*appsv
 			}
 		}
 
-		// Add resource requests (e.g., SR-IOV VFs)
-		if len(dp.ResourceRequests) > 0 {
-			container.Resources = corev1.ResourceRequirements{
-				Requests: dp.ResourceRequests,
-				Limits:   dp.ResourceRequests, // extended resources require limits == requests
-			}
+		// Set default resource requests
+		requests := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("50M"),
+		}
+		// Merge any additional resource requests (e.g., SR-IOV VFs)
+		for k, v := range dp.ResourceRequests {
+			requests[k] = v
+		}
+		container.Resources = corev1.ResourceRequirements{
+			Requests: requests,
+			Limits:   dp.ResourceRequests, // only set limits for extended resources
 		}
 
 		cmdContainers = append(cmdContainers, container)
@@ -1565,6 +1659,7 @@ func CreateDeployment(dp DeploymentParams, client *kubernetes.Clientset) (*appsv
 					ServiceAccountName:            sa,
 					HostNetwork:                   dp.HostNetwork,
 					Containers:                    cmdContainers,
+					Tolerations:                   dp.Tolerations,
 					Affinity: &corev1.Affinity{
 						NodeAffinity:    &dp.NodeAffinity,
 						PodAffinity:     &dp.PodAffinity,

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -1056,7 +1056,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		cdpHostAcross.NodeAffinity = affinity
 	}
 
-	if ncount > 1 {
+	if ncount > 1 && !s.NodeLocal {
 		if s.HostNetwork {
 			cdpHostAcross.NodeAffinity = corev1.NodeAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: zoneNodeSelectorExpression(*client, z, "client"),

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -675,11 +675,45 @@ func NodeLabelSelector(nodeSelectors map[string]string) string {
 	return "node-role.kubernetes.io/worker="
 }
 
+// runIDLabel is the label key used to scope resources to a single run.
+const runIDLabel = "k8s-netperf/run-id"
+
+// runName returns base when runID is empty, otherwise base-runID for unique names.
+func runName(base, runID string) string {
+	if runID == "" {
+		return base
+	}
+	return base + "-" + runID
+}
+
+// runLabels returns role/run-id labels for a deployment or service.
+func runLabels(role, runID string) map[string]string {
+	l := map[string]string{"role": role}
+	if runID != "" {
+		l[runIDLabel] = runID
+	}
+	return l
+}
+
+// runMatchExpressions builds a LabelSelector matching role + run-id (when set).
+func runMatchExpressions(role, runID string) []metav1.LabelSelectorRequirement {
+	exprs := []metav1.LabelSelectorRequirement{
+		{Key: "role", Operator: metav1.LabelSelectorOpIn, Values: []string{role}},
+	}
+	if runID != "" {
+		exprs = append(exprs, metav1.LabelSelectorRequirement{
+			Key: runIDLabel, Operator: metav1.LabelSelectorOpIn, Values: []string{runID},
+		})
+	}
+	return exprs
+}
+
 // BuildSUT Build the k8s env to run network performance tests
 func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	var netperfDataPorts []int32
 	var netperfVmDataPorts []int32
 	var err error
+	rid := s.RunID
 
 	// Build SR-IOV resource requests if needed
 	var sriovResources corev1.ResourceList
@@ -727,11 +761,11 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			networkAnnotations = buildMacvlanNetworkAnnotations()
 		}
 		cdp := DeploymentParams{
-			Name:               "client",
+			Name:               runName("client", rid),
 			Namespace:          namespace,
 			Replicas:           1,
 			Image:              k8sNetperfImage,
-			Labels:             map[string]string{"role": clientRole},
+			Labels:             runLabels(clientRole, rid),
 			Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 			Port:               NetperfServerCtlPort,
 			NetworkAnnotations: networkAnnotations,
@@ -796,9 +830,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	clientRoleAffinity := []corev1.PodAffinityTerm{
 		{
 			LabelSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: "role", Operator: metav1.LabelSelectorOpIn, Values: []string{clientRole}},
-				},
+				MatchExpressions: runMatchExpressions(clientRole, rid),
 			},
 			TopologyKey: "kubernetes.io/hostname",
 		},
@@ -818,12 +850,12 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			networkAnnotations = buildMacvlanNetworkAnnotations()
 		}
 		cdp := DeploymentParams{
-			Name:               "client",
+			Name:               runName("client", rid),
 			Namespace:          namespace,
 			Replicas:           1,
 			HostNetwork:        s.HostNetwork,
 			Image:              k8sNetperfImage,
-			Labels:             map[string]string{"role": clientRole},
+			Labels:             runLabels(clientRole, rid),
 			Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 			Port:               NetperfServerCtlPort,
 			NetworkAnnotations: networkAnnotations,
@@ -870,9 +902,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		if s.Pod {
 			// Create iperf service
 			iperfSVC := ServiceParams{
-				Name:      "iperf-service",
+				Name:      runName("iperf-service", rid),
 				Namespace: namespace,
-				Labels:    map[string]string{"role": serverRole},
+				Labels:    runLabels(serverRole, rid),
 				CtlPort:   IperfServerCtlPort,
 				DataPorts: []int32{IperfServerDataPort},
 			}
@@ -884,9 +916,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		if s.VM {
 			// Create iperf VM service
 			iperfSVC := ServiceParams{
-				Name:      "iperf-vm-service",
+				Name:      runName("iperf-vm-service", rid),
 				Namespace: namespace,
-				Labels:    map[string]string{"role": vmServerRole},
+				Labels:    runLabels(vmServerRole, rid),
 				CtlPort:   IperfServerCtlPort,
 				DataPorts: []int32{IperfVmServerDataPort},
 			}
@@ -901,9 +933,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		if s.Pod {
 			// Create uperf service
 			uperfSVC := ServiceParams{
-				Name:      "uperf-service",
+				Name:      runName("uperf-service", rid),
 				Namespace: namespace,
-				Labels:    map[string]string{"role": serverRole},
+				Labels:    runLabels(serverRole, rid),
 				CtlPort:   UperfServerCtlPort,
 				DataPorts: []int32{UperfServerDataPort},
 			}
@@ -926,9 +958,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		}
 		if s.VM {
 			uperfSVC := ServiceParams{
-				Name:      "uperf-vm-service",
+				Name:      runName("uperf-vm-service", rid),
 				Namespace: namespace,
-				Labels:    map[string]string{"role": vmServerRole},
+				Labels:    runLabels(vmServerRole, rid),
 				CtlPort:   UperfServerCtlPort,
 				DataPorts: []int32{UperfVmServerDataPort},
 			}
@@ -958,9 +990,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				netperfDataPorts = append(netperfDataPorts, NetperfServerDataPort+int32(i))
 			}
 			netperfSVC := ServiceParams{
-				Name:      "netperf-service",
+				Name:      runName("netperf-service", rid),
 				Namespace: namespace,
-				Labels:    map[string]string{"role": serverRole},
+				Labels:    runLabels(serverRole, rid),
 				CtlPort:   NetperfServerCtlPort,
 				DataPorts: netperfDataPorts,
 			}
@@ -975,9 +1007,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 				netperfVmDataPorts = append(netperfVmDataPorts, NetperfServerDataPort+int32(i))
 			}
 			netperfSVC := ServiceParams{
-				Name:      "netperf-vm-service",
+				Name:      runName("netperf-vm-service", rid),
 				Namespace: namespace,
-				Labels:    map[string]string{"role": vmServerRole},
+				Labels:    runLabels(vmServerRole, rid),
 				CtlPort:   NetperfServerCtlPort,
 				DataPorts: netperfVmDataPorts,
 			}
@@ -1000,11 +1032,11 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		networkAnnotations = buildMacvlanNetworkAnnotations()
 	}
 	cdpAcross := DeploymentParams{
-		Name:               "client-across",
+		Name:               runName("client-across", rid),
 		Namespace:          namespace,
 		Replicas:           1,
 		Image:              k8sNetperfImage,
-		Labels:             map[string]string{"role": clientAcrossRole},
+		Labels:             runLabels(clientAcrossRole, rid),
 		Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 		Port:               NetperfServerCtlPort,
 		NetworkAnnotations: networkAnnotations,
@@ -1017,12 +1049,12 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	}
 
 	cdpHostAcross := DeploymentParams{
-		Name:        "client-host",
+		Name:        runName("client-host", rid),
 		Namespace:   namespace,
 		Replicas:    1,
 		HostNetwork: true,
 		Image:       k8sNetperfImage,
-		Labels:      map[string]string{"role": hostNetClientRole},
+		Labels:      runLabels(hostNetClientRole, rid),
 		Commands:    [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 		Port:        NetperfServerCtlPort,
 		Privileged:  s.Privileged,
@@ -1149,12 +1181,12 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	}
 
 	sdpHost := DeploymentParams{
-		Name:        "server-host",
+		Name:        runName("server-host", rid),
 		Namespace:   namespace,
 		Replicas:    1,
 		HostNetwork: true,
 		Image:       k8sNetperfImage,
-		Labels:      map[string]string{"role": hostNetServerRole},
+		Labels:      runLabels(hostNetServerRole, rid),
 		Commands:    dpCommands,
 		Port:        NetperfServerCtlPort,
 		Privileged:  s.Privileged,
@@ -1162,11 +1194,11 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	}
 	// Start netperf server
 	sdp := DeploymentParams{
-		Name:               "server",
+		Name:               runName("server", rid),
 		Namespace:          namespace,
 		Replicas:           1,
 		Image:              k8sNetperfImage,
-		Labels:             map[string]string{"role": serverRole},
+		Labels:             runLabels(serverRole, rid),
 		Commands:           dpCommands,
 		Port:               NetperfServerCtlPort,
 		NetworkAnnotations: networkAnnotations,
@@ -1222,9 +1254,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
 					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{Key: "role", Operator: metav1.LabelSelectorOpIn, Values: []string{clientAcrossRole}},
-						},
+						MatchExpressions: runMatchExpressions(clientAcrossRole, rid),
 					},
 					TopologyKey: "kubernetes.io/hostname",
 				},
@@ -1235,9 +1265,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
 					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{Key: "role", Operator: metav1.LabelSelectorOpIn, Values: []string{hostNetClientRole}},
-						},
+						MatchExpressions: runMatchExpressions(hostNetClientRole, rid),
 					},
 					TopologyKey: "kubernetes.io/hostname",
 				},
@@ -1703,7 +1731,7 @@ func GetPods(c *kubernetes.Clientset, label string) (corev1.PodList, error) {
 	log.Infof("Looking for pods with label %s", fmt.Sprint(label))
 	pods, err := c.CoreV1().Pods(namespace).List(context.TODO(), listOpt)
 	if err != nil {
-		return *pods, fmt.Errorf("❌ Failure to capture pods: %v", err)
+		return corev1.PodList{}, fmt.Errorf("❌ Failure to capture pods: %v", err)
 	}
 	return *pods, nil
 

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -180,15 +180,24 @@ func buildSriovNetworkAnnotations() map[string]string {
 	return annotations
 }
 
-// ReadNamespaceFromFile reads a namespace YAML file and returns the namespace name.
-func ReadNamespaceFromFile(filePath string) (string, error) {
+// parseNamespaceFromFile reads and unmarshals a namespace YAML file.
+func parseNamespaceFromFile(filePath string) (*corev1.Namespace, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return "", fmt.Errorf("unable to read namespace file %s: %v", filePath, err)
+		return nil, fmt.Errorf("unable to read namespace file %s: %v", filePath, err)
 	}
 	var ns corev1.Namespace
 	if err := yaml.Unmarshal(data, &ns); err != nil {
-		return "", fmt.Errorf("unable to parse namespace file %s: %v", filePath, err)
+		return nil, fmt.Errorf("unable to parse namespace file %s: %v", filePath, err)
+	}
+	return &ns, nil
+}
+
+// ReadNamespaceFromFile reads a namespace YAML file and returns the namespace name.
+func ReadNamespaceFromFile(filePath string) (string, error) {
+	ns, err := parseNamespaceFromFile(filePath)
+	if err != nil {
+		return "", err
 	}
 	if ns.Name == "" {
 		return "", fmt.Errorf("namespace file %s must have metadata.name set", filePath)
@@ -198,16 +207,12 @@ func ReadNamespaceFromFile(filePath string) (string, error) {
 
 // createNamespaceFromFile reads a namespace YAML file and creates the namespace.
 func createNamespaceFromFile(client *kubernetes.Clientset, filePath string) error {
-	data, err := os.ReadFile(filePath)
+	ns, err := parseNamespaceFromFile(filePath)
 	if err != nil {
-		return fmt.Errorf("unable to read namespace file %s: %v", filePath, err)
-	}
-	var ns corev1.Namespace
-	if err := yaml.Unmarshal(data, &ns); err != nil {
-		return fmt.Errorf("unable to parse namespace file %s: %v", filePath, err)
+		return err
 	}
 	log.Infof("🔨 Creating namespace %s from file: %s", ns.Name, filePath)
-	_, err = client.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+	_, err = client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 	return err
 }
 
@@ -822,9 +827,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		return err
 	}
 	ncount := len(nodes.Items)
-	log.Debugf("Number of nodes with role worker: %d", ncount)
+	log.Debugf("Number of nodes matching selector %q: %d", nodeCountSelector, ncount)
 	if !s.NodeLocal && ncount < 2 {
-		return fmt.Errorf("not enough nodes with label worker= to execute test (current number of nodes: %d)", ncount)
+		return fmt.Errorf("not enough nodes matching selector %q to execute test (current number of nodes: %d)", nodeCountSelector, ncount)
 	}
 
 	clientRoleAffinity := []corev1.PodAffinityTerm{
@@ -945,9 +950,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			}
 			// Create uperf-histogram service
 			uperfLatSVC := ServiceParams{
-				Name:      "uperf-histogram-service",
-				Namespace: "netperf",
-				Labels:    map[string]string{"role": serverRole},
+				Name:      runName("uperf-histogram-service", rid),
+				Namespace: namespace,
+				Labels:    runLabels(serverRole, rid),
 				CtlPort:   UperfLatServerCtlPort,
 				DataPorts: []int32{UperfLatServerDataPort},
 			}
@@ -970,9 +975,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			}
 			//
 			uperfLatSVC := ServiceParams{
-				Name:      "uperf-vm-histogram-service",
-				Namespace: "netperf",
-				Labels:    map[string]string{"role": vmServerRole},
+				Name:      runName("uperf-vm-histogram-service", rid),
+				Namespace: namespace,
+				Labels:    runLabels(vmServerRole, rid),
 				CtlPort:   UperfLatServerCtlPort,
 				DataPorts: []int32{UperfLatVmServerDataPort},
 			}

--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -3,6 +3,9 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
 	"time"
 
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/v2/ocp-metadata"
@@ -11,6 +14,32 @@ import (
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// JsonFloat64 is a float64 that always marshals with a decimal point,
+// ensuring OpenSearch consistently maps the field as a float type.
+type JsonFloat64 float64
+
+func (f JsonFloat64) MarshalJSON() ([]byte, error) {
+	v := float64(f)
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return []byte("0.0"), nil
+	}
+	s := strconv.FormatFloat(v, 'f', -1, 64)
+	// Ensure there's always a decimal point
+	if !strings.Contains(s, ".") {
+		s += ".0"
+	}
+	return []byte(s), nil
+}
+
+func (f *JsonFloat64) UnmarshalJSON(data []byte) error {
+	var v float64
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*f = JsonFloat64(v)
+	return nil
+}
 
 // NodeInfo stores the node metadata like IP and Hostname
 type NodeInfo struct {
@@ -21,27 +50,27 @@ type NodeInfo struct {
 
 // NodeCPU stores CPU information for a specific Node
 type NodeCPU struct {
-	Idle       float64 `json:"idleCPU"`
-	User       float64 `json:"userCPU"`
-	Steal      float64 `json:"stealCPU"`
-	System     float64 `json:"systemCPU"`
-	Nice       float64 `json:"niceCPU"`
-	Irq        float64 `json:"irqCPU"`
-	Softirq    float64 `json:"softCPU"`
-	Iowait     float64 `json:"ioCPU"`
-	VSwitchCPU float64 `json:"vSwitchCPU"`
-	VSwitchMem float64 `json:"vSwitchMem"`
+	Idle       JsonFloat64 `json:"idleCPU"`
+	User       JsonFloat64 `json:"userCPU"`
+	Steal      JsonFloat64 `json:"stealCPU"`
+	System     JsonFloat64 `json:"systemCPU"`
+	Nice       JsonFloat64 `json:"niceCPU"`
+	Irq        JsonFloat64 `json:"irqCPU"`
+	Softirq    JsonFloat64 `json:"softCPU"`
+	Iowait     JsonFloat64 `json:"ioCPU"`
+	VSwitchCPU JsonFloat64 `json:"vSwitchCPU"`
+	VSwitchMem JsonFloat64 `json:"vSwitchMem"`
 }
 
 // PodCPU stores pod CPU
 type PodCPU struct {
-	Name  string  `json:"podName"`
-	Value float64 `json:"cpuUsage"`
+	Name  string      `json:"podName"`
+	Value JsonFloat64 `json:"cpuUsage"`
 }
 
 type PodMem struct {
-	Name  string  `json:"podName"`
-	Value float64 `json:"memUsage"`
+	Name  string      `json:"podName"`
+	Value JsonFloat64 `json:"memUsage"`
 }
 
 // PodValues is a collection of PodCPU
@@ -80,8 +109,7 @@ func Discover(meta *ocpmetadata.Metadata) (PromConnect, bool) {
 	var err error
 	conn.URL, conn.Token, err = meta.GetPrometheus()
 	if err != nil {
-		logging.Info("😥 prometheus discovery failure")
-		logging.Error(err)
+		logging.Debug("Prometheus auto-discovery not available (non-OpenShift cluster or route not exposed)")
 		return conn, false
 	}
 	logging.Info("🔬 prometheus discovery succeeded")
@@ -386,12 +414,12 @@ func topPodMemQuery(node NodeInfo, conn PromConnect) string {
 }
 
 // Calculates average for the given data
-func avg(data []model.SamplePair) float64 {
+func avg(data []model.SamplePair) JsonFloat64 {
 	sum := 0.0
 	for s := range data {
 		sum += float64(data[s].Value)
 	}
-	return sum / float64(len(data))
+	return JsonFloat64(sum / float64(len(data)))
 }
 
 // Unmarshals the vector to a given type

--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -427,8 +427,8 @@ func unmarshalVector(value model.Value, pd interface{}) bool {
 	v := value.(model.Vector)
 	for _, s := range v {
 		d, _ := s.MarshalJSON()
-		error := json.Unmarshal(d, &pd)
-		if error != nil {
+		err := json.Unmarshal(d, &pd)
+		if err != nil {
 			continue
 		} else {
 			return true

--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -427,7 +427,7 @@ func unmarshalVector(value model.Value, pd interface{}) bool {
 	v := value.(model.Vector)
 	for _, s := range v {
 		d, _ := s.MarshalJSON()
-		err := json.Unmarshal(d, &pd)
+		err := json.Unmarshal(d, pd)
 		if err != nil {
 			continue
 		} else {

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -62,6 +62,7 @@ type Data struct {
 // ScenarioResults each scenario could have multiple results
 type ScenarioResults struct {
 	Results   []Data
+	Tags      []string
 	Virt      bool
 	Version   string
 	GitCommit string


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [x] Bug fix
- [x] Optimization
- [x] Documentation Update

## Description

First of all, thanks for this project. I’m currently using it to test our network performance.

While working with it, I found a few areas that needed adjustments or improvements, which led to the changes in this PR. I’m aware that it would be cleaner to split these into smaller, separate PRs or commits.

None of the changes here are intended to alter the core behavior of the tool. If a larger PR like this isn’t something you’d prefer to review or merge, feel free to close it.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing

The tests were run on a bare-metal Kubernetes cluster in an active environment. The cluster includes things like a validation webhook and node taints, which can interfere with running the tool as-is.

Some of the changes in this PR are meant to work around these constraints. For example, automatically adding tolerations by detecting node taints so the tests can be scheduled and executed properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom kubeconfig files, target namespaces, namespace YAML files, node selectors, and taint tolerations.
  - Added run-specific resource isolation to enable concurrent benchmark runs.
  - Added `--tag` support for labeling results in CSV, JSON, and OpenSearch outputs.
  - Improved resource requests and scheduling behavior across selected nodes.

- **Bug Fixes**
  - Standardized metric serialization and safely normalizes invalid numeric values.

- **Documentation**
  - Updated setup instructions, CLI flag details, namespace management, concurrent runs, and Prometheus guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->