### PR TITLE
MACVLAN support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,9 @@ jobs:
           kubectl -n kube-system wait --for=condition=Ready pod -l app=whereabouts --timeout=120s
           for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
             docker exec "$node" bash -c 'curl -sSL https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz | tar -xz -C /opt/cni/bin ./macvlan'
+            docker exec "$node" bash -c 'ip link add macvlan0 type dummy && ip link set macvlan0 up'
           done
 
       - name: Run MACVLAN tests
         run: |
-          ./bin/amd64/k8s-netperf --debug --macvlan eth0 --tcp-tolerance 100
+          ./bin/amd64/k8s-netperf --debug --macvlan macvlan0 --tcp-tolerance 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,19 @@ jobs:
       - name: Run UDN L2 tests (using SVC)
         run: |
           ./bin/amd64/k8s-netperf --debug --udnl2 --config examples/netperf-svc.yml
+
+      - name: Install Multus and MACVLAN prerequisites
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset-thick.yml
+          kubectl -n kube-system wait --for=condition=Ready pod -l app=multus --timeout=120s
+          kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/master/doc/crds/daemonset-install.yaml \
+            -f https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml \
+            -f https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+          kubectl -n kube-system wait --for=condition=Ready pod -l app=whereabouts --timeout=120s
+          for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+            docker exec "$node" bash -c 'curl -sSL https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz | tar -xz -C /opt/cni/bin ./macvlan'
+          done
+
+      - name: Run MACVLAN tests
+        run: |
+          ./bin/amd64/k8s-netperf --debug --macvlan eth0 --tcp-tolerance 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
 
       - name: Run MACVLAN tests
         run: |
-          ./bin/amd64/k8s-netperf --debug --macvlan macvlan0 --tcp-tolerance 100
+          ./bin/amd64/k8s-netperf --debug --macvlan macvlan0 --local --tcp-tolerance 100

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For detailed documentation, please refer to the following guides:
 
 - **[Setup and Installation](docs/setup.md)** - How to build, install, and configure k8s-netperf
 - **[Configuration](docs/configuration.md)** - Configuration file formats, benchmark options, and OpenSearch integration
-- **[Advanced Usage](docs/advanced-usage.md)** - VMs, User Defined Networks (UDN), bridge networks, and external servers
+- **[Advanced Usage](docs/advanced-usage.md)** - VMs, User Defined Networks (UDN), bridge networks, SR-IOV, MACVLAN and external servers
 - **[Output and Results](docs/output-and-results.md)** - Understanding test output, pass/fail criteria, and CSV exports
 
 ## Features
@@ -61,7 +61,7 @@ For detailed documentation, please refer to the following guides:
 - **Multiple benchmark tools**: Support for netperf, iperf3, uperf and ib_write_bw
 - **Flexible test scenarios**: Pod-to-pod, host networking, cross-AZ testing
 - **Virtual Machine support**: Test with KubeVirt VMs
-- **Advanced networking**: User Defined Networks (UDN), bridge interfaces, and SR-IOV
+- **Advanced networking**: User Defined Networks (UDN), bridge interfaces, SR-IOV and MACVLAN
 - **Pass/fail validation**: Automated performance regression detection
 - **Result archiving**: CSV export and OpenSearch integration
 - **Prometheus integration**: System metrics collection during tests

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -153,6 +153,9 @@ var rootCmd = &cobra.Command{
 		if macvlan != "" && hostNetOnly {
 			log.Fatalf("😭 --macvlan cannot be used with --hostNet")
 		}
+		if macvlan != "" && vm {
+			log.Fatalf("😭 --macvlan cannot be used with --vm")
+		}
 
 		// If a specific driver is explicitly requested, disable the default netperf driver
 		if (iperf3 || uperf || ibWriteBwEnabled) && !cmd.Flags().Changed("netperf") {

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -59,8 +59,9 @@ var (
 	bridge           string
 	bridgeNetwork    string
 	bridgeNamespace  string
-	sriov            string
+	sriov             string
 	sriovNodeSelector string
+	macvlan           string
 	promURL          string
 	id               string
 	searchURL        string
@@ -137,6 +138,21 @@ var rootCmd = &cobra.Command{
 		if sriov != "" && vm && pod {
 			log.Fatalf("😭 --sriov with --vm requires --pod=false. Pod SR-IOV uses deviceType netdevice while VM SR-IOV uses vfio-pci — they cannot share the same VFs.")
 		}
+		if macvlan != "" && bridge != "" {
+			log.Fatalf("😭 --macvlan and --bridge are mutually exclusive")
+		}
+		if macvlan != "" && sriov != "" {
+			log.Fatalf("😭 --macvlan and --sriov are mutually exclusive")
+		}
+		if macvlan != "" && ibWriteBwEnabled {
+			log.Fatalf("😭 --macvlan and --ib-write-bw are mutually exclusive")
+		}
+		if macvlan != "" && (udnl2 || udnl3 || cudn != "") {
+			log.Fatalf("😭 --macvlan cannot be used with UDN flags (--udnl2, --udnl3, --cudn)")
+		}
+		if macvlan != "" && hostNetOnly {
+			log.Fatalf("😭 --macvlan cannot be used with --hostNet")
+		}
 
 		// If a specific driver is explicitly requested, disable the default netperf driver
 		if (iperf3 || uperf || ibWriteBwEnabled) && !cmd.Flags().Changed("netperf") {
@@ -192,6 +208,7 @@ var rootCmd = &cobra.Command{
 			BridgeNetwork:   bridge,
 			BridgeNamespace: bridgeNamespace,
 			SriovNetwork:    sriov,
+			MacvlanNetwork:  macvlan,
 			Cudn:            cudn != "",
 			IbWriteBwParams: ibWriteBw,
 			Sockets:         sockets,
@@ -336,6 +353,21 @@ var rootCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 			err = k8s.WaitForSriovNad(s.DClient)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		// Deploy MACVLAN NAD if requested
+		if macvlan != "" {
+			if s.DClient == nil {
+				dynClient, err := dynamic.NewForConfig(rconfig)
+				if err != nil {
+					log.Fatalf("Failed to create dynamic client for MACVLAN: %v", err)
+				}
+				s.DClient = dynClient
+			}
+			err = k8s.DeployNADMacvlan(s.DClient, macvlan)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -715,6 +747,13 @@ func executeWorkload(nc config.Config,
 
 		// Set bridge info similar to UdnInfo
 		npr.BridgeInfo = fmt.Sprintf("%s/%s", s.BridgeNamespace, s.BridgeNetwork)
+	} else if s.MacvlanNetwork != "" {
+		serverIP, err = k8s.ExtractMacvlanIp(s.Server.Items[0])
+		if err != nil {
+			log.Fatalf("Failed to extract MACVLAN IP: %v", err)
+		}
+		log.Debugf("Using MACVLAN network IP: %s", serverIP)
+		npr.MacvlanInfo = fmt.Sprintf("macvlan/%s", s.MacvlanNetwork)
 	} else if s.BridgeServerNetwork != "" {
 		// For VMs, use static bridge IP from JSON config
 		serverIP = strings.Split(s.BridgeServerNetwork, "/")[0]
@@ -837,6 +876,7 @@ func main() {
 	rootCmd.Flags().StringVar(&bridgeNetwork, "bridgeNetwork", "bridgeNetwork.json", "Json file for the VM network defined by the bridge interface - bridge should be enabled (default bridgeNetwork.json)")
 	rootCmd.Flags().StringVar(&sriov, "sriov", "", "SR-IOV PF interface name (e.g., ens1f0). Creates SriovNetworkNodePolicy and SriovNetwork CRs. Requires SR-IOV operator.")
 	rootCmd.Flags().StringVar(&sriovNodeSelector, "sriov-node-selector", "worker", "Node role label for SR-IOV node selector (default worker)")
+	rootCmd.Flags().StringVar(&macvlan, "macvlan", "", "MACVLAN master interface name (e.g., eth0). Creates a MACVLAN NetworkAttachmentDefinition.")
 	rootCmd.Flags().StringVar(&promURL, "prom", "", "Prometheus URL")
 	rootCmd.Flags().StringVar(&id, "uuid", "", "User provided UUID")
 	rootCmd.Flags().StringVar(&searchURL, "search", "", "OpenSearch URL, if you have auth, pass in the format of https://user:pass@url:port")

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -93,7 +93,26 @@ Requirements for VM SR-IOV:
 
 > Note: Pod and VM SR-IOV tests cannot run in the same invocation because pods require `deviceType: netdevice` while VMs require `deviceType: vfio-pci`. Run them separately with `--pod=false` for VM-only or without `--vm` for pod-only.
 
-> Note: `--sriov` is mutually exclusive with `--bridge`, `--ib-write-bw`, `--hostNet`, and UDN flags (`--udnl2`, `--udnl3`, `--cudn`).
+> Note: `--sriov` is mutually exclusive with `--bridge`, `--macvlan`, `--ib-write-bw`, `--hostNet` and UDN flags (`--udnl2`, `--udnl3`, `--cudn`).
+
+## MACVLAN Network Testing
+To run k8s-netperf over a MACVLAN interface, pass the master (host) interface name to the `--macvlan` flag. k8s-netperf will automatically create a MACVLAN `NetworkAttachmentDefinition` with [whereabouts](https://github.com/k8snetworkplumbingwg/whereabouts) IPAM in the `netperf` namespace and clean it up after the test.
+
+Prerequisites:
+- [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) must be installed on the cluster
+- The `macvlan` CNI plugin must be available on the nodes (`/opt/cni/bin/macvlan`)
+- The whereabouts IPAM plugin must be installed
+
+```bash
+k8s-netperf --macvlan eth0
+```
+
+On a single-node cluster:
+```bash
+k8s-netperf --macvlan eth0 --local
+```
+
+> Note: `--macvlan` is mutually exclusive with `--bridge`, `--sriov`, `--ib-write-bw`, `--hostNet` and UDN flags (`--udnl2`, `--udnl3`, `--cudn`).
 
 ## Using a Linux Bridge Interface
 When using `--bridge`, a NetworkAttachmentDefinition defining a bridge interface is attached to the VMs and is used for the test. It requires the name of the bridge as it is defined in the NetworkNodeConfigurationPolicy, NMstate operator is required.

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -59,6 +59,7 @@ type Doc struct {
 	UdnInfo           string           `json:"udnInfo"`
 	BridgeInfo        string           `json:"bridgeInfo"`
 	SriovInfo         string           `json:"sriovInfo"`
+	MacvlanInfo       string           `json:"macvlanInfo"`
 }
 
 // Connect returns a client connected to the desired cluster.
@@ -134,6 +135,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 			UdnInfo:           r.UdnInfo,
 			BridgeInfo:        r.BridgeInfo,
 			SriovInfo:         r.SriovInfo,
+			MacvlanInfo:       r.MacvlanInfo,
 		}
 		UDPLossPercent, e := result.Average(r.LossSummary)
 		if e != nil {
@@ -181,6 +183,7 @@ func commonCsvHeaderFields() []string {
 		"UDN Info",
 		"Bridge Info",
 		"SR-IOV Info",
+		"Macvlan Info",
 		"Duration",
 		"Parallelism",
 		"# of Samples",
@@ -208,6 +211,7 @@ func commonCsvDataFields(row result.Data) []string {
 		fmt.Sprint(row.UdnInfo),
 		fmt.Sprint(row.BridgeInfo),
 		fmt.Sprint(row.SriovInfo),
+		fmt.Sprint(row.MacvlanInfo),
 		strconv.Itoa(row.Duration),
 		strconv.Itoa(row.Parallelism),
 		strconv.Itoa(row.Samples),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,7 @@ type PerfScenarios struct {
 	BridgeServerNetwork string
 	BridgeClientNetwork string
 	SriovNetwork        string
+	MacvlanNetwork      string
 	IbWriteBwParams     string
 	Sockets             uint32
 	Cores               uint32

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -104,6 +104,7 @@ const CudnName = "cudn-secondary-netperf"
 const SriovNadName = "sriov-netperf"
 const SriovPolicyName = "sriov-netperf-policy"
 const sriovOperatorNamespace = "openshift-sriov-network-operator"
+const MacvlanNadName = "macvlan-netperf"
 
 // ValidateBridgeNetwork validates that the specified bridge namespace and NetworkAttachmentDefinition exist
 func ValidateBridgeNetwork(client *kubernetes.Clientset, dyn dynamic.Interface, bridgeNetwork, bridgeNamespace string) error {
@@ -160,6 +161,76 @@ func buildSriovNetworkAnnotations() map[string]string {
 	annotations["k8s.v1.cni.cncf.io/networks"] = namespace + "/" + SriovNadName
 	log.Infof("🌉 Configuring SR-IOV network: %s", namespace+"/"+SriovNadName)
 	return annotations
+}
+
+// buildMacvlanNetworkAnnotations creates the network annotations for Multus CNI MACVLAN networks
+func buildMacvlanNetworkAnnotations() map[string]string {
+	annotations := make(map[string]string)
+	annotations["k8s.v1.cni.cncf.io/networks"] = namespace + "/" + MacvlanNadName
+	log.Infof("🌉 Configuring MACVLAN network: %s", namespace+"/"+MacvlanNadName)
+	return annotations
+}
+
+// DeployNADMacvlan creates a NetworkAttachmentDefinition for MACVLAN in the netperf namespace
+func DeployNADMacvlan(dyn *dynamic.DynamicClient, master string) error {
+	log.Infof("Deploying MACVLAN NetworkAttachmentDefinition with master: %s", master)
+	nadMacvlan := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "k8s.cni.cncf.io/v1",
+			"kind":       "NetworkAttachmentDefinition",
+			"metadata": map[string]interface{}{
+				"name":      MacvlanNadName,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"config": fmt.Sprintf(`{"cniVersion": "0.3.1", "type": "macvlan", "master": "%s", "mode": "bridge", "ipam": {"type": "whereabouts", "range": "192.168.200.0/24"}}`, master),
+			},
+		},
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    "k8s.cni.cncf.io",
+		Version:  "v1",
+		Resource: "network-attachment-definitions",
+	}
+	_, err := dyn.Resource(gvr).Namespace(namespace).Create(context.TODO(), nadMacvlan, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to create MACVLAN NAD: %v", err)
+	}
+	return nil
+}
+
+// ExtractMacvlanIp extracts the MACVLAN network IP address from pod network status annotation
+func ExtractMacvlanIp(pod corev1.Pod) (string, error) {
+	networkStatusJson := pod.Annotations["k8s.v1.cni.cncf.io/network-status"]
+	if networkStatusJson == "" {
+		return "", fmt.Errorf("no network status annotation found on pod %s", pod.Name)
+	}
+
+	var networkStatuses []struct {
+		Name      string   `json:"name"`
+		Interface string   `json:"interface"`
+		IPs       []string `json:"ips"`
+		Default   bool     `json:"default,omitempty"`
+	}
+
+	err := json.Unmarshal([]byte(networkStatusJson), &networkStatuses)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling network status: %v", err)
+	}
+
+	expectedNetworkName := fmt.Sprintf("%s/%s", namespace, MacvlanNadName)
+	for _, netStatus := range networkStatuses {
+		if netStatus.Name == expectedNetworkName && len(netStatus.IPs) > 0 {
+			for _, ip := range netStatus.IPs {
+				if strings.Contains(ip, ".") {
+					log.Debugf("Pod %s MACVLAN network IP: %s", pod.Name, ip)
+					return ip, nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("MACVLAN network IP not found for %s on pod %s", expectedNetworkName, pod.Name)
 }
 
 // BuildInfra will create the infra for the SUT
@@ -568,6 +639,8 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			networkAnnotations = buildCUdnNetworkAnnotations(CudnName)
 		} else if s.SriovNetwork != "" {
 			networkAnnotations = buildSriovNetworkAnnotations()
+		} else if s.MacvlanNetwork != "" {
+			networkAnnotations = buildMacvlanNetworkAnnotations()
 		}
 		cdp := DeploymentParams{
 			Name:               "client",
@@ -655,6 +728,8 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			networkAnnotations = buildCUdnNetworkAnnotations(CudnName)
 		} else if s.SriovNetwork != "" {
 			networkAnnotations = buildSriovNetworkAnnotations()
+		} else if s.MacvlanNetwork != "" {
+			networkAnnotations = buildMacvlanNetworkAnnotations()
 		}
 		cdp := DeploymentParams{
 			Name:               "client",
@@ -810,6 +885,8 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		networkAnnotations = buildCUdnNetworkAnnotations(CudnName)
 	} else if s.SriovNetwork != "" {
 		networkAnnotations = buildSriovNetworkAnnotations()
+	} else if s.MacvlanNetwork != "" {
+		networkAnnotations = buildMacvlanNetworkAnnotations()
 	}
 	cdpAcross := DeploymentParams{
 		Name:               "client-across",

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -50,6 +50,7 @@ type Data struct {
 	UdnInfo           string
 	BridgeInfo        string
 	SriovInfo         string
+	MacvlanInfo       string
 	Virt              bool
 }
 
@@ -196,13 +197,13 @@ func calDiff(a float64, b float64) float64 {
 
 // ShowPodCPU accepts ScenarioResults and presents to the user via stdout the PodCPU info
 func ShowPodCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Macvlan Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodCPU.Results {
-			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -210,13 +211,13 @@ func ShowPodCPU(s ScenarioResults) {
 
 // ShowPodMem accepts ScenarioResults and presents to the user via stdout the Podmem info
 func ShowPodMem(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Macvlan Info", "Message Size", "Burst", "Same node", "Pod", "Utilization"})
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 		for _, pod := range r.ServerPodMem.MemResults {
-			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+			table.Append([]string{"Pod Mem RSS Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
 		}
 	}
 	table.Render()
@@ -224,7 +225,7 @@ func ShowPodMem(s ScenarioResults) {
 
 // ShowNodeCPU accepts ScenarioResults and presents to the user via stdout the NodeCPU info
 func ShowNodeCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Macvlan Info", "Message Size", "Burst", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
 	for _, r := range s.Results {
 		// Skip RR/CRR iperf3 Results
 		if strings.Contains(r.Profile, "RR") {
@@ -235,11 +236,11 @@ func ShowNodeCPU(s ScenarioResults) {
 		ccpu := r.ClientMetrics
 		scpu := r.ServerMetrics
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", ccpu.Idle), fmt.Sprintf("%f", ccpu.User), fmt.Sprintf("%f", ccpu.System), fmt.Sprintf("%f", ccpu.Steal), fmt.Sprintf("%f", ccpu.Iowait), fmt.Sprintf("%f", ccpu.Nice), fmt.Sprintf("%f", ccpu.Softirq), fmt.Sprintf("%f", ccpu.Irq),
 		})
 		table.Append([]string{
-			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Virt), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%d", r.Burst), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", scpu.Idle), fmt.Sprintf("%f", scpu.User), fmt.Sprintf("%f", scpu.System), fmt.Sprintf("%f", scpu.Steal), fmt.Sprintf("%f", scpu.Iowait), fmt.Sprintf("%f", scpu.Nice), fmt.Sprintf("%f", scpu.Softirq), fmt.Sprintf("%f", scpu.Irq),
 		})
 	}
@@ -248,15 +249,15 @@ func ShowNodeCPU(s ScenarioResults) {
 
 // ShowSpecificResults
 func ShowSpecificResults(s ScenarioResults) {
-	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
+	table := initTable([]string{"Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Macvlan Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, "TCP_STREAM") {
 			rt, _ := Average(r.RetransmitSummary)
-			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
+			table.Append([]string{"TCP Retransmissions", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (rt))})
 		}
 		if strings.Contains(r.Profile, "UDP_STREAM") {
 			loss, _ := Average(r.LossSummary)
-			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
+			table.Append([]string{"UDP Loss Percent", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f", (loss))})
 		}
 	}
 	table.Render()
@@ -264,7 +265,7 @@ func ShowSpecificResults(s ScenarioResults) {
 
 // Abstracts out the common code for results
 func renderResults(s ScenarioResults, testType string) {
-	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
+	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Macvlan Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg value", "95% Confidence Interval"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, testType) {
 			if len(r.Driver) > 0 {
@@ -273,7 +274,7 @@ func renderResults(s ScenarioResults, testType string) {
 				if r.Samples > 1 {
 					_, lo, hi = ConfidenceInterval(r.ThroughputSummary, 0.95)
 				}
-				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
+				table.Append([]string{fmt.Sprintf("📊 %s Results", caser.String(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric), fmt.Sprintf("%f-%f (%s)", lo, hi, r.Metric)})
 			}
 		}
 	}
@@ -302,11 +303,11 @@ func ShowRRResult(s ScenarioResults) {
 func ShowLatencyResult(s ScenarioResults) {
 	if checkResults(s, "RR") {
 		logging.Debug("Rendering RR P99 Latency results")
-		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
+		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Macvlan Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
 				p99, _ := Average(r.LatencySummary)
-				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
+				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, r.MacvlanInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
 			}
 		}
 		table.Render()


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `--macvlan` flag to run network performance tests over macvlan NADs. When specified, k8s-netperf creates the corresponding NAD and deploys pods with corresponding annotations.

It also adds a new macvlan test to the CI workflow run.

## Related issues

- Closes https://github.com/cloud-bulldozer/k8s-netperf/issues/223

## Testing

Tested on a kind cluster:
```
$ cat macvlan-test.yml
tests:
- TCPStream:
  parallelism: 1
  profile: "TCP_STREAM"
  duration: 5
  samples: 1
  messagesize: 1024

$ ./bin/amd64/k8s-netperf --local --macvlan eth0 --config macvlan-test.yml
INFO[2026-04-30 14:30:14] Starting k8s-netperf (macvlan@31338e95599020f1ac1792465ef73d2fc7bc8703)
INFO[2026-04-30 14:30:14] 📒 Reading macvlan-test.yml file.
INFO[2026-04-30 14:30:14] 📒 Reading macvlan-test.yml file - using ConfigV2 Method.
W0430 14:30:14.532273  553265 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W0430 14:30:14.532289  553265 client_config.go:664] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
ERRO[2026-04-30 14:30:14] invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
WARN[2026-04-30 14:30:14] 😥 Prometheus is not available
INFO[2026-04-30 14:30:14] 🔨 Creating namespace: netperf
INFO[2026-04-30 14:30:14] 🔨 Creating service account: netperf
INFO[2026-04-30 14:30:14] Deploying MACVLAN NetworkAttachmentDefinition with master: eth0
WARN[2026-04-30 14:30:14] ⚠️  No zone label
WARN[2026-04-30 14:30:14] ⚠️  Single node per zone and/or no zone labels
INFO[2026-04-30 14:30:14] 🌉 Configuring MACVLAN network: netperf/macvlan-netperf
INFO[2026-04-30 14:30:14] 🚀 Starting Deployment for: client in namespace: netperf
INFO[2026-04-30 14:30:14] ⏰ Checking for client Pods to become ready...
^[[BINFO[2026-04-30 14:30:47] Looking for pods with label role=client-local
INFO[2026-04-30 14:30:47] 🚀 Creating service for netperf-service in namespace netperf
INFO[2026-04-30 14:30:47] 🌉 Configuring MACVLAN network: netperf/macvlan-netperf
INFO[2026-04-30 14:30:47] 🚀 Starting Deployment for: server in namespace: netperf
INFO[2026-04-30 14:30:47] ⏰ Checking for server Pods to become ready...
INFO[2026-04-30 14:30:49] Looking for pods with label role=server
INFO[2026-04-30 14:30:54] 🗒️  Running netperf TCP_STREAM (service false) for 5s
WARN[2026-04-30 14:31:01] Not able to collect OpenShift specific node info
+-------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | SR-IOV INFO | MACVLAN INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |      AVG VALUE      | 95% CONFIDENCE INTERVAL  |
+-------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false     | false   | false           |          |             |             | macvlan/eth0 | 1024         | 0     | true      | 5        | 1       | 15793.770000 (Mb/s) | 0.000000-0.000000 (Mb/s) |
+-------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+--------------+-------+-----------+----------+---------+---------------------+--------------------------+
+---------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+--------------+-------+-----------+----------+---------+-----------+
|        TYPE         | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | SR-IOV INFO | MACVLAN INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES | AVG VALUE |
+---------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+--------------+-------+-----------+----------+---------+-----------+
| TCP Retransmissions | netperf | TCP_STREAM | 1           | false        | false     | false   | false           |          |             |             | macvlan/eth0 | 1024         | 0     | true      | 5        | 1       | 0.000000  |
+---------------------+---------+------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+--------------+-------+-----------+----------+---------+-----------+
INFO[2026-04-30 14:31:01] Cleaning resources created by k8s-netperf
INFO[2026-04-30 14:31:01] ⏰ Waiting for netperf Namespace to be deleted...
```