### PR TITLE
TCP stream latency

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -798,7 +798,9 @@ func executeWorkload(nc config.Config,
 		npr.LossSummary = append(npr.LossSummary, float64(nr.LossPercent))
 		npr.RetransmitSummary = append(npr.RetransmitSummary, nr.Retransmits)
 		npr.ThroughputSummary = append(npr.ThroughputSummary, nr.Throughput)
-		npr.LatencySummary = append(npr.LatencySummary, nr.Latency99ptile)
+		npr.LatencyAvgSummary = append(npr.LatencyAvgSummary, nr.Latency)
+		npr.Latency50Summary = append(npr.Latency50Summary, nr.Latency50ptile)
+		npr.Latency99Summary = append(npr.Latency99Summary, nr.Latency99ptile)
 	}
 	npr.EndTime = time.Now()
 	npr.ClientNodeInfo = s.ClientNodeInfo

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -800,7 +800,7 @@ func executeWorkload(nc config.Config,
 		npr.ThroughputSummary = append(npr.ThroughputSummary, nr.Throughput)
 		npr.LatencyAvgSummary = append(npr.LatencyAvgSummary, nr.Latency)
 		npr.Latency50Summary = append(npr.Latency50Summary, nr.Latency50ptile)
-		npr.Latency99Summary = append(npr.Latency99Summary, nr.Latency99ptile)
+		npr.LatencySummary = append(npr.LatencySummary, nr.Latency99ptile)
 	}
 	npr.EndTime = time.Now()
 	npr.ClientNodeInfo = s.ClientNodeInfo

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -33,6 +33,13 @@ RUN curl -L https://github.com/esnet/iperf/releases/download/3.16/iperf-3.16.tar
     cd .. && \
     rm -rf iperf-3.16
 
+# Build uperf_histogram from uperf's histogram branch
+RUN git clone https://github.com/rafaelfolco/uperf.git uperf_histogram && \
+    cd uperf_histogram && git checkout master && \
+    autoreconf --install && ./configure --prefix=/opt/uperf-histogram --disable-sctp && make install && \
+    ldconfig && /opt/uperf-histogram/bin/uperf -V && \
+    cd .. && \
+    rm -rf uperf_histogram
 
 RUN rm -rf netperf && \
     dnf clean all

--- a/netperf.yml
+++ b/netperf.yml
@@ -45,8 +45,8 @@ tests:
 
   - TCPStreamLatency:
     parallelism: 1
-    profile: "TCP_STREAM_LAT"
+    profile: "TCP_STREAM_LAT" # Only available with the uperf driver
     duration: 10
     samples: 3
     messagesize: 1024
-    # messagereadsize: 1  # Optional: defaults to 1 byte if not specified
+    # messagereadsize: 1      # Optional: defaults to 1 byte if not specified

--- a/netperf.yml
+++ b/netperf.yml
@@ -42,3 +42,11 @@ tests:
     duration: 10
     samples: 3
     messagesize: 1024
+
+  - TCPStreamLatency:
+    parallelism: 1
+    profile: "TCP_STREAM_LAT"
+    duration: 10
+    samples: 3
+    messagesize: 1024
+    # messagereadsize: 1  # Optional: defaults to 1 byte if not specified

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -156,7 +156,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 		} else {
 			d.Throughput = Throughput
 		}
-		Latency, e := result.Average(r.LatencySummary)
+		Latency, e := result.Average(r.Latency99Summary)
 		if e != nil {
 			logging.Warn("Unable to process latency, setting value to zero")
 			d.Latency = 0
@@ -441,7 +441,7 @@ func WriteCSVResult(r result.ScenarioResults) error {
 	}
 	for _, row := range r.Results {
 		avg, _ := result.Average(row.ThroughputSummary)
-		lavg, _ := result.Average(row.LatencySummary)
+		lavg, _ := result.Average(row.Latency99Summary)
 		data := append(commonCsvDataFields(row),
 			fmt.Sprintf("%f", avg),
 			row.Metric,

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -156,7 +156,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 		} else {
 			d.Throughput = Throughput
 		}
-		Latency, e := result.Average(r.Latency99Summary)
+		Latency, e := result.Average(r.LatencySummary)
 		if e != nil {
 			logging.Warn("Unable to process latency, setting value to zero")
 			d.Latency = 0
@@ -441,7 +441,7 @@ func WriteCSVResult(r result.ScenarioResults) error {
 	}
 	for _, row := range r.Results {
 		avg, _ := result.Average(row.ThroughputSummary)
-		lavg, _ := result.Average(row.Latency99Summary)
+		lavg, _ := result.Average(row.LatencySummary)
 		data := append(commonCsvDataFields(row),
 			fmt.Sprintf("%f", avg),
 			row.Metric,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,7 +98,7 @@ type BridgeNetworkConfig struct {
 }
 
 // Tests we will support in k8s-netperf
-const validTests = "tcp_stream|udp_stream|tcp_rr|udp_rr|tcp_crr|udp_crr|sctp_stream|sctp_rr|sctp_crr"
+const validTests = "tcp_stream_lat|tcp_stream|udp_stream|tcp_rr|udp_rr|tcp_crr|udp_crr|sctp_stream|sctp_rr|sctp_crr"
 
 func validConfig(cfg Config) (bool, error) {
 	preEval := regexp.MustCompile("(?i)" + validTests)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,15 +25,16 @@ type VMExecutor interface {
 
 // Config describes the netperf tests
 type Config struct {
-	Parallelism int    `default:"1" yaml:"parallelism,omitempty"`
-	Duration    int    `yaml:"duration,omitempty"`
-	Profile     string `yaml:"profile,omitempty"`
-	Samples     int    `yaml:"samples,omitempty"`
-	MessageSize int    `yaml:"messagesize,omitempty"`
-	Burst       int    `yaml:"burst,omitempty"`
-	Service     bool   `default:"false" yaml:"service,omitempty"`
-	Metric      string
-	AcrossAZ    bool
+	Parallelism     int    `default:"1" yaml:"parallelism,omitempty"`
+	Duration        int    `yaml:"duration,omitempty"`
+	Profile         string `yaml:"profile,omitempty"`
+	Samples         int    `yaml:"samples,omitempty"`
+	MessageSize     int    `yaml:"messagesize,omitempty"`
+	MessageReadSize int    `yaml:"messagereadsize,omitempty"`
+	Burst           int    `yaml:"burst,omitempty"`
+	Service         bool   `default:"false" yaml:"service,omitempty"`
+	Metric          string
+	AcrossAZ        bool
 }
 
 // PerfScenarios describes the different scenarios
@@ -77,9 +78,11 @@ type PerfScenarios struct {
 	NetperfService      *apiv1.Service
 	IperfService        *apiv1.Service
 	UperfService        *apiv1.Service
+	UperfLatService     *apiv1.Service
 	NetperfVmService    *apiv1.Service
 	IperfVmService      *apiv1.Service
 	UperfVmService      *apiv1.Service
+	UperfLatVmService   *apiv1.Service
 	RestConfig          rest.Config
 	ClientSet           *kubernetes.Clientset
 	KClient             *kubevirtv1.KubevirtV1Client

--- a/pkg/drivers/iperf.go
+++ b/pkg/drivers/iperf.go
@@ -40,7 +40,7 @@ type IperfResult struct {
 
 // IsTestSupported Determine if the test is supported for driver
 func (i *iperf3) IsTestSupported() bool {
-	return strings.Contains(i.testConfig.Profile, "STREAM")
+	return i.testConfig.Profile != "TCP_STREAM_LAT" && strings.Contains(i.testConfig.Profile, "STREAM")
 }
 
 // Run will invoke iperf3 in a client container

--- a/pkg/drivers/netperf.go
+++ b/pkg/drivers/netperf.go
@@ -225,5 +225,5 @@ func (n *netperf) ParseResults(stdout *bytes.Buffer, _ config.Config) (sample.Sa
 
 // IsTestSupported Determine if the test is supported for driver
 func (n *netperf) IsTestSupported() bool {
-	return true
+	return n.testConfig.Profile != "TCP_STREAM_LAT"
 }

--- a/pkg/drivers/uperf.go
+++ b/pkg/drivers/uperf.go
@@ -56,20 +56,47 @@ func createUperfProfile(c *kubernetes.Clientset, rc rest.Config, nc config.Confi
 	}
 
 	if strings.Contains(nc.Profile, "STREAM") {
-		fileContent = fmt.Sprintf(`<?xml version=1.0?>
-		<profile name="stream-%s-%d-%d">
-		<group nprocs="%d">
-		<transaction iterations="1">
-		  <flowop type="connect" options="remotehost=%s protocol=%s port=%d"/>
-		</transaction>
-		<transaction duration="%d">		  
-		  <flowop type=write options="count=16 size=%d"/>
-		<transaction iterations="1">
-		  <flowop type=disconnect />
-		</transaction>
-		</group>		
-		</profile>`, protocol, nc.MessageSize, nc.Parallelism, nc.Parallelism, serverIP, protocol, k8s.UperfServerCtlPort+1, nc.Duration, nc.MessageSize)
-		filePath = fmt.Sprintf("/tmp/uperf-stream-%s-%d-%d", protocol, nc.MessageSize, nc.Parallelism)
+		// TCP_STREAM_LAT uses a different flow with read operation
+		if nc.Profile == "TCP_STREAM_LAT" {
+			// Default message read size to 1 byte if not specified
+			messageReadSize := nc.MessageReadSize
+			if messageReadSize == 0 {
+				messageReadSize = 1
+			}
+			fileContent = fmt.Sprintf(`<?xml version=1.0?>
+			<profile name="stream-%s-%d-%d">
+			<group nprocs="%d">
+			<transaction iterations="1">
+			  <flowop type="connect" options="remotehost=%s protocol=%s port=%d"/>
+			</transaction>
+			<transaction duration="%d">
+			  <flowop type=write options="count=16 size=%d"/>
+			  <flowop type=read options="count=16 size=%d"/>
+			</transaction>
+			<transaction iterations="1">
+			  <flowop type=disconnect />
+			</transaction>
+			</group>
+			</profile>`, protocol, nc.MessageSize, nc.Parallelism, nc.Parallelism, serverIP, protocol, k8s.UperfLatServerDataPort, nc.Duration, nc.MessageSize, messageReadSize)
+			filePath = fmt.Sprintf("/tmp/uperf-stream-lat-%s-%d-%d", protocol, nc.MessageSize, nc.Parallelism)
+		} else {
+			// Standard STREAM profile (write only)
+			fileContent = fmt.Sprintf(`<?xml version=1.0?>
+			<profile name="stream-%s-%d-%d">
+			<group nprocs="%d">
+			<transaction iterations="1">
+			  <flowop type="connect" options="remotehost=%s protocol=%s port=%d"/>
+			</transaction>
+			<transaction duration="%d">
+			  <flowop type=write options="count=16 size=%d"/>
+			</transaction>
+			<transaction iterations="1">
+			  <flowop type=disconnect />
+			</transaction>
+			</group>
+			</profile>`, protocol, nc.MessageSize, nc.Parallelism, nc.Parallelism, serverIP, protocol, k8s.UperfServerDataPort, nc.Duration, nc.MessageSize)
+			filePath = fmt.Sprintf("/tmp/uperf-stream-%s-%d-%d", protocol, nc.MessageSize, nc.Parallelism)
+		}
 	} else {
 		fileContent = fmt.Sprintf(`<?xml version=1.0?>		
 		<profile name="rr-%s-%d-%d">
@@ -85,7 +112,7 @@ func createUperfProfile(c *kubernetes.Clientset, rc rest.Config, nc config.Confi
 		  <flowop type=disconnect />
 		</transaction>
 		</group>		
-		</profile>`, protocol, nc.MessageSize, nc.Parallelism, nc.Parallelism, serverIP, protocol, k8s.UperfServerCtlPort+1, nc.Duration, nc.MessageSize, nc.MessageSize)
+		</profile>`, protocol, nc.MessageSize, nc.Parallelism, nc.Parallelism, serverIP, protocol, k8s.UperfServerDataPort, nc.Duration, nc.MessageSize, nc.MessageSize)
 		filePath = fmt.Sprintf("/tmp/uperf-rr-%s-%d-%d", protocol, nc.MessageSize, nc.Parallelism)
 	}
 
@@ -194,7 +221,11 @@ func (u *uperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, c
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
+	// Select binary based on profile
 	cmd := []string{"uperf", "-v", "-a", "-R", "-i", "1", "-m", filePath, "-P", fmt.Sprint(k8s.UperfServerCtlPort)}
+	if nc.Profile == "TCP_STREAM_LAT" {
+		cmd = []string{"/opt/uperf-histogram/bin/uperf", "-v", "-a", "-R", "-i", "1", "-m", filePath, "-P", fmt.Sprint(k8s.UperfLatServerCtlPort), "-H", "stdout"}
+	}
 	log.Debug(cmd)
 
 	// VM mode
@@ -291,7 +322,7 @@ func (u *uperf) Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, c
 
 // ParseResults accepts the stdout from the execution of the benchmark.
 // It will return a Sample struct or error
-func (u *uperf) ParseResults(stdout *bytes.Buffer, _ config.Config) (sample.Sample, error) {
+func (u *uperf) ParseResults(stdout *bytes.Buffer, nc config.Config) (sample.Sample, error) {
 	var prevTimestamp, normLtcy float64
 	var prevBytes, prevOps, normOps float64
 	var byteSummary, latSummary, opSummary []float64
@@ -333,7 +364,29 @@ func (u *uperf) ParseResults(stdout *bytes.Buffer, _ config.Config) (sample.Samp
 		tputUnit = "Mbps"
 	}
 	sample.Latency99ptile, _ = stats.Percentile(latSummary, 99)
-	log.Debugf("Storing uperf sample throughput: P99 Latency %f, Throughput: %f %s", sample.Latency99ptile, sample.Throughput, tputUnit)
+
+	// Parse uperf histogram if available for more accurate percentile measurements
+	if nc.Profile == "TCP_STREAM_LAT" {
+		// Parse average and percentiles from histogram output
+		avgRegex := regexp.MustCompile(`Average\s*:\s*(\d+(?:\.\d+)?)`)
+		p50Regex := regexp.MustCompile(`50th\s*:\s*(\d+(?:\.\d+)?)`)
+		p99Regex := regexp.MustCompile(`99th\s*:\s*(\d+(?:\.\d+)?)`)
+
+		output := stdout.String()
+		if match := avgRegex.FindStringSubmatch(output); len(match) > 1 {
+			sample.Latency, _ = strconv.ParseFloat(match[1], 64)
+		}
+		if match := p50Regex.FindStringSubmatch(output); len(match) > 1 {
+			sample.Latency50ptile, _ = strconv.ParseFloat(match[1], 64)
+		}
+		if match := p99Regex.FindStringSubmatch(output); len(match) > 1 {
+			sample.Latency99ptile, _ = strconv.ParseFloat(match[1], 64)
+		}
+
+		log.Debugf("Storing uperf-histogram sample: Avg Latency %f, P50 Latency %f, P99 Latency %f, Throughput: %f %s", sample.Latency, sample.Latency50ptile, sample.Latency99ptile, sample.Throughput, tputUnit)
+	} else {
+		log.Debugf("Storing uperf sample throughput: P99 Latency %f, Throughput: %f %s", sample.Latency99ptile, sample.Throughput, tputUnit)
+	}
 
 	return sample, nil
 

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -72,6 +72,7 @@ const IperfServerCtlPort = 22865
 
 // UperferverCtlPort control port for the service
 const UperfServerCtlPort = 30000
+const UperfLatServerCtlPort = 31000
 
 // NetperfServerDataPort data port for the service
 const NetperfServerDataPort = 42424
@@ -87,9 +88,11 @@ const IperfVmServerDataPort = 43533
 
 // UperfServerDataPort data port for the service
 const UperfServerDataPort = 30001
+const UperfLatServerDataPort = 31001
 
 // UperfServerDataPort data port for the service
 const UperfVmServerDataPort = 30101
+const UperfLatVmServerDataPort = 31101
 
 // Labels we will apply to k8s assets.
 const serverRole = "server"
@@ -466,8 +469,8 @@ func DeploySriovNetwork(dyn *dynamic.DynamicClient, resourceName string) error {
 			},
 			"spec": map[string]interface{}{
 				"networkNamespace": namespace,
-				"resourceName":    resourceName,
-				"ipam":            `{"type": "whereabouts", "range": "192.168.100.0/24"}`,
+				"resourceName":     resourceName,
+				"ipam":             `{"type": "whereabouts", "range": "192.168.100.0/24"}`,
 			},
 		},
 	}
@@ -749,6 +752,18 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			if err != nil {
 				return fmt.Errorf("😥 Unable to create uperf service: %v", err)
 			}
+			// Create uperf-histogram service
+			uperfLatSVC := ServiceParams{
+				Name:      "uperf-histogram-service",
+				Namespace: "netperf",
+				Labels:    map[string]string{"role": serverRole},
+				CtlPort:   UperfLatServerCtlPort,
+				DataPorts: []int32{UperfLatServerDataPort},
+			}
+			s.UperfLatService, err = CreateService(uperfLatSVC, client)
+			if err != nil {
+				return fmt.Errorf("😥 Unable to create uperf-histogram service: %v", err)
+			}
 		}
 		if s.VM {
 			uperfSVC := ServiceParams{
@@ -761,6 +776,18 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			s.UperfVmService, err = CreateService(uperfSVC, client)
 			if err != nil {
 				return fmt.Errorf("😥 Unable to create uperf service: %v", err)
+			}
+			//
+			uperfLatSVC := ServiceParams{
+				Name:      "uperf-vm-histogram-service",
+				Namespace: "netperf",
+				Labels:    map[string]string{"role": vmServerRole},
+				CtlPort:   UperfLatServerCtlPort,
+				DataPorts: []int32{UperfLatVmServerDataPort},
+			}
+			s.UperfLatVmService, err = CreateService(uperfLatSVC, client)
+			if err != nil {
+				return fmt.Errorf("😥 Unable to create uperf-histogram service: %v", err)
 			}
 		}
 	}
@@ -923,6 +950,21 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		dpCommands = append(dpCommands, []string{"/bin/bash", "-c", fmt.Sprintf("iperf3 -s -p %d && sleep 10000000", IperfServerCtlPort)})
 	}
 	if containsDriver(s.RequestedDrivers, "uperf") {
+		// Check if any config uses TCP_STREAM_LAT profile
+		needsHistogram := false
+		for _, cfg := range s.Configs {
+			if cfg.Profile == "TCP_STREAM_LAT" {
+				needsHistogram = true
+				break
+			}
+		}
+
+		// Start uperf_histogram server only if TCP_STREAM_LAT is used
+		if needsHistogram {
+			dpCommands = append(dpCommands, []string{"/bin/bash", "-c", fmt.Sprintf("/opt/uperf-histogram/bin/uperf -s -v -P %d && sleep 10000000", UperfLatServerCtlPort)})
+		}
+
+		// Always start regular uperf server for other profiles
 		dpCommands = append(dpCommands, []string{"/bin/bash", "-c", fmt.Sprintf("uperf -s -v -P %d && sleep 10000000", UperfServerCtlPort)})
 	}
 	if containsDriver(s.RequestedDrivers, "ib_write_bw") {

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -36,10 +36,12 @@ type Data struct {
 	EndTime           time.Time
 	Service           bool
 	AcrossAZ          bool
-	ThroughputSummary []float64
-	LatencySummary    []float64
-	LossSummary       []float64
-	RetransmitSummary []float64
+	ThroughputSummary  []float64
+	LatencyAvgSummary  []float64
+	Latency50Summary   []float64
+	Latency99Summary     []float64
+	LossSummary        []float64
+	RetransmitSummary  []float64
 	ClientMetrics     metrics.NodeCPU
 	ServerMetrics     metrics.NodeCPU
 	ClientPodCPU      metrics.PodValues
@@ -300,12 +302,27 @@ func ShowRRResult(s ScenarioResults) {
 
 // ShowLatencyResult accepts NetPerfResults to display to the user via stdout
 func ShowLatencyResult(s ScenarioResults) {
+
+	if checkResults(s, "STREAM_LAT") {
+		logging.Debug("Rendering TCP_STREAM_LAT Avg, P50 and P99 Latency results")
+		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg Latency", "Avg 50%tile value", "Avg 99%tile value"})
+		for _, r := range s.Results {
+			if strings.Contains(r.Profile, "STREAM_LAT") {
+				avg, _ := Average(r.LatencyAvgSummary)
+				p50, _ := Average(r.Latency50Summary)
+				p99, _ := Average(r.Latency99Summary)
+				table.Append([]string{"Stream Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, "usec"), fmt.Sprintf("%f (%s)", p50, "usec"), fmt.Sprintf("%f (%s)", p99, "usec")})
+			}
+		}
+		table.Render()
+	}
+
 	if checkResults(s, "RR") {
 		logging.Debug("Rendering RR P99 Latency results")
 		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
-				p99, _ := Average(r.LatencySummary)
+				p99, _ := Average(r.Latency99Summary)
 				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
 			}
 		}

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -39,7 +39,7 @@ type Data struct {
 	ThroughputSummary  []float64
 	LatencyAvgSummary  []float64
 	Latency50Summary   []float64
-	Latency99Summary     []float64
+	LatencySummary     []float64 // 99%tile latency summary
 	LossSummary        []float64
 	RetransmitSummary  []float64
 	ClientMetrics     metrics.NodeCPU
@@ -310,7 +310,7 @@ func ShowLatencyResult(s ScenarioResults) {
 			if strings.Contains(r.Profile, "STREAM_LAT") {
 				avg, _ := Average(r.LatencyAvgSummary)
 				p50, _ := Average(r.Latency50Summary)
-				p99, _ := Average(r.Latency99Summary)
+				p99, _ := Average(r.LatencySummary)
 				table.Append([]string{"Stream Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, "usec"), fmt.Sprintf("%f (%s)", p50, "usec"), fmt.Sprintf("%f (%s)", p99, "usec")})
 			}
 		}
@@ -322,7 +322,7 @@ func ShowLatencyResult(s ScenarioResults) {
 		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Virt mode", "Service", "External Server", "UDN Info", "Bridge Info", "SR-IOV Info", "Message Size", "Burst", "Same node", "Duration", "Samples", "Avg 99%tile value"})
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
-				p99, _ := Average(r.Latency99Summary)
+				p99, _ := Average(r.LatencySummary)
 				table.Append([]string{"RR Latency Results", r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Virt), strconv.FormatBool(r.Service), fmt.Sprintf("%t", r.ExternalServer), r.UdnInfo, r.BridgeInfo, r.SriovInfo, strconv.Itoa(r.MessageSize), strconv.Itoa(r.Burst), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
 			}
 		}

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -36,12 +36,12 @@ type Data struct {
 	EndTime           time.Time
 	Service           bool
 	AcrossAZ          bool
-	ThroughputSummary  []float64
-	LatencyAvgSummary  []float64
-	Latency50Summary   []float64
-	LatencySummary     []float64 // 99%tile latency summary
-	LossSummary        []float64
-	RetransmitSummary  []float64
+	ThroughputSummary []float64
+	LatencyAvgSummary []float64
+	Latency50Summary  []float64
+	LatencySummary    []float64 // 99%tile latency summary
+	LossSummary       []float64
+	RetransmitSummary []float64
 	ClientMetrics     metrics.NodeCPU
 	ServerMetrics     metrics.NodeCPU
 	ClientPodCPU      metrics.PodValues

--- a/pkg/sample/types.go
+++ b/pkg/sample/types.go
@@ -3,6 +3,7 @@ package sample
 // Sample describes the values we will return with each execution.
 type Sample struct {
 	Latency        float64
+	Latency50ptile float64
 	Latency99ptile float64
 	Throughput     float64
 	LossPercent    float64


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

- Related Issue #

Addresses issue #234 

- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Validated in an OCP 4.20 MNO.

As part of k8s-netperf startup time, one can now see a second uperf (histogram) starting:

```
DEBU[2026-04-30 16:36:02] 🔥 Server Commands: RequestedDrivers=[uperf], len=1 
DEBU[2026-04-30 16:36:02] 🔥 Final dpCommands count: 2                  
DEBU[2026-04-30 16:36:02] 🔥 dpCommand[0]: [/bin/bash -c /opt/uperf-histogram/bin/uperf -s -v -P 31000 && sleep 10000000] 
DEBU[2026-04-30 16:36:02] 🔥 dpCommand[1]: [/bin/bash -c uperf -s -v -P 30000 && sleep 10000000] 
INFO[2026-04-30 16:36:02] HostNetwork is not supported for server VM... skipping 
```
Which is only started, if the corresponding test is specified in netperf.yml:

```
  - TCPStreamLatency:
    parallelism: 1
    profile: "TCP_STREAM_LAT"
    duration: 10
    samples: 3
    messagesize: 1024
    # messagereadsize: 1  # Optional: defaults to 1 byte if not specified
```
Which results in the stdout:

```
INFO[2026-04-30 16:36:34] 🗒️  Running uperf TCP_STREAM_LAT (service false) for 10s  
DEBU[2026-04-30 16:36:34] Creating uperf configuration file            
DEBU[2026-04-30 16:36:34]                                              
DEBU[2026-04-30 16:36:34] [/opt/uperf-histogram/bin/uperf -v -a -R -i 1 -m /tmp/uperf-stream-lat-tcp-1024-1 -P 31000 -H stdout] 
DEBU[2026-04-30 16:36:47] Storing uperf histogram sample: Avg Latency 41095.880000, P50 Latency 41009.000000, P99 Latency 42040.000000, Throughput: 3.201267 Mbps 
DEBU[2026-04-30 16:36:47] 🔥 Client (client-across-75db99cc9-nktf2,10.128.9.31) starting uperf against server: 10.129.9.30 
INFO[2026-04-30 16:36:47] 🗒️  Running uperf TCP_STREAM_LAT (service false) for 10s  
DEBU[2026-04-30 16:36:47] Creating uperf configuration file            
DEBU[2026-04-30 16:36:47]                                              
DEBU[2026-04-30 16:36:47] [/opt/uperf-histogram/bin/uperf -v -a -R -i 1 -m /tmp/uperf-stream-lat-tcp-1024-1 -P 31000 -H stdout] 
DEBU[2026-04-30 16:36:59] Storing uperf histogram sample: Avg Latency 41102.150000, P50 Latency 41003.000000, P99 Latency 42065.000000, Throughput: 3.201267 Mbps 
DEBU[2026-04-30 16:36:59] 🔥 Client (client-across-75db99cc9-nktf2,10.128.9.31) starting uperf against server: 10.129.9.30 
INFO[2026-04-30 16:36:59] 🗒️  Running uperf TCP_STREAM_LAT (service false) for 10s  
DEBU[2026-04-30 16:36:59] Creating uperf configuration file            
DEBU[2026-04-30 16:36:59]                                              
DEBU[2026-04-30 16:36:59] [/opt/uperf-histogram/bin/uperf -v -a -R -i 1 -m /tmp/uperf-stream-lat-tcp-1024-1 -P 31000 -H stdout] 
DEBU[2026-04-30 16:37:12] Storing uperf histogram sample: Avg Latency 41053.550000, P50 Latency 41006.000000, P99 Latency 42077.000000, Throughput: 3.201267 Mbps 
```
And gets parsed into the table:

```
+-------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+--------------------+--------------------------+
|    RESULT TYPE    | DRIVER |    SCENARIO    | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | SR-IOV INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG VALUE      | 95% CONFIDENCE INTERVAL  |
+-------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+--------------------+--------------------------+
| 📊 Stream Results | uperf  | TCP_STREAM     | 1           | false        | false     | false   | false           |          |             |             | 1024         | 0     | false     | 10       | 1       | 8134.603571 (Mb/s) | 0.000000-0.000000 (Mb/s) |
| 📊 Stream Results | uperf  | TCP_STREAM_LAT | 1           | false        | false     | false   | false           |          |             |             | 1024         | 0     | false     | 10       | 3       | 3.201267 (Mb/s)    | 3.201267-3.201267 (Mb/s) |
+-------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+--------------------+--------------------------+
(...)
DEBU[2026-04-30 16:37:12] Rendering TCP_STREAM_LAT Avg, P50 and P99 Latency results 
+------------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+---------------------+---------------------+---------------------+
|      RESULT TYPE       | DRIVER |    SCENARIO    | PARALLELISM | HOST NETWORK | VIRT MODE | SERVICE | EXTERNAL SERVER | UDN INFO | BRIDGE INFO | SR-IOV INFO | MESSAGE SIZE | BURST | SAME NODE | DURATION | SAMPLES |     AVG LATENCY     |  AVG 50%TILE VALUE  |  AVG 99%TILE VALUE  |
+------------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+---------------------+---------------------+---------------------+
| Stream Latency Results | uperf  | TCP_STREAM_LAT | 1           | false        | false     | false   | false           |          |             |             | 1024         | 0     | false     | 10       | 3       | 41083.860000 (usec) | 41006.000000 (usec) | 42060.666667 (usec) |
+------------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+---------------------+---------------------+---------------------+
(...)
+---------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+-----------+
| TCP Retransmissions | uperf  | TCP_STREAM     | 1           | false        | false     | false   | false           |          |             |             | 1024         | 0     | false     | 10       | 1       | 0.000000  |
| TCP Retransmissions | uperf  | TCP_STREAM_LAT | 1           | false        | false     | false   | false           |          |             |             | 1024         | 0     | false     | 10       | 3       | 0.000000  |
+---------------------+--------+----------------+-------------+--------------+-----------+---------+-----------------+----------+-------------+-------------+--------------+-------+-----------+----------+---------+-----------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TCP Stream Latency test profile for detailed latency analysis.
  * Collects average, 50th- and 99th-percentile latency per sample.
  * Displays avg/P50/P99 in latency results.

* **Chores**
  * Container now builds/install a histogram-enabled uperf binary for latency profiling.

* **Config**
  * Configuration updated to accept and validate the new latency profile and related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->