### PR TITLE
Preserve CSV output when OpenSearch indexing fails

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -158,6 +158,19 @@ var rootCmd = &cobra.Command{
 			log.SetDebug()
 		}
 
+		searchIndexName := index
+		if len(searchIndex) > 1 {
+			searchIndexName = searchIndex
+		}
+		var esClient *indexers.Indexer
+		if len(searchURL) > 1 {
+			var err error
+			esClient, err = archive.Connect(searchURL, searchIndexName, true)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
 		cfg, err := config.ParseConf(cfgfile)
 		if err != nil {
 			cf, err := config.ParseV2Conf(cfgfile)
@@ -490,33 +503,6 @@ var rootCmd = &cobra.Command{
 			sr.MTU = mtu
 		}
 
-		if len(searchURL) > 1 {
-			var esClient *indexers.Indexer
-			jdocs, err := archive.BuildDocs(sr, uid)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if len(searchIndex) > 1 {
-				esClient, err = archive.Connect(searchURL, searchIndex, true)
-				if err != nil {
-					log.Fatal(err)
-				}
-			} else {
-				esClient, err = archive.Connect(searchURL, index, true)
-				if err != nil {
-					log.Fatal(err)
-				}
-
-			}
-			log.Infof("Indexing [%d] documents in %s with UUID %s", len(jdocs), index, uid)
-			resp, err := (*esClient).Index(jdocs, indexers.IndexingOpts{})
-			if err != nil {
-				log.Error(err.Error())
-			} else {
-				log.Info(resp)
-			}
-		}
-
 		if !json {
 			result.ShowStreamResult(sr)
 			result.ShowRRResult(sr)
@@ -534,14 +520,30 @@ var rootCmd = &cobra.Command{
 			}
 		}
 		if csvArchive {
-			if archive.WriteCSVResult(sr) != nil {
+			if err := archive.WriteCSVResult(sr); err != nil {
 				log.Fatal(err)
 			}
-			if pavail && archive.WritePromCSVResult(sr) != nil {
+			if pavail {
+				if err := archive.WritePromCSVResult(sr); err != nil {
+					log.Fatal(err)
+				}
+			}
+			if err := archive.WriteSpecificCSV(sr); err != nil {
 				log.Fatal(err)
 			}
-			if archive.WriteSpecificCSV(sr) != nil {
+		}
+
+		if len(searchURL) > 1 {
+			jdocs, err := archive.BuildDocs(sr, uid)
+			if err != nil {
 				log.Fatal(err)
+			}
+			log.Infof("Indexing [%d] documents in %s with UUID %s", len(jdocs), searchIndexName, uid)
+			resp, err := (*esClient).Index(jdocs, indexers.IndexingOpts{})
+			if err != nil {
+				log.Error(err.Error())
+			} else {
+				log.Info(resp)
 			}
 		}
 		// Initially we are just checking against TCP_STREAM results.


### PR DESCRIPTION
A transient OpenSearch outage at the end of a long run was fatal and discarded all CSV output, because the indexer connect/index block ran before the CSV-writing block and used log.Fatal on connect failure.

Move CSV/JSON writing to run before final OpenSearch indexing, and perform the indexer connect once at startup as a preflight so a misconfigured or unreachable endpoint fails fast instead of after the benchmark completes. Keep BuildDocs failure fatal: it indicates a code or data contract bug, not a transient outage, and CSVs are already on disk by that point.

Final Index() errors remain non-fatal.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Reorders the post-benchmark steps in `cmd/k8s-netperf/k8s-netperf.go` so that durable local artifacts (CSV, JSON) are written before any best-effort network step, and adds a single OpenSearch preflight connect at startup.

Concretely:
- New preflight: when `--search` is set, `archive.Connect` runs once during initialization. If it fails, the run aborts before any benchmark work begins, so users do not lose a 75-minute run to a misconfigured or unreachable endpoint.
- Reuse: the resulting `*indexers.Indexer` is held and reused for the final indexing call, eliminating the duplicate connect-with-default-index / connect-with-custom-index branches that existed before.
- Reorder: CSV and JSON writing now run before the final `Index()` call, so a transient OpenSearch failure at the tail of a run cannot prevent CSVs from landing on disk.
- Error policy: `Index()` errors remain `log.Error` (non-fatal). `BuildDocs` failure remains `log.Fatal` because it indicates a code/data-contract defect rather than a transient outage, and CSVs are already on disk by the time it runs.

No behavior change to the benchmark itself, no flag changes, no schema changes.

## Related Tickets & Documents

- Fixes #252

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- **System Under Test:** OpenShift cluster with k8s-netperf invoked using `--search=https://...` (OpenSearch indexer enabled) and `--csv=true`.
- **Steps:**
  1. Misconfigured endpoint → run k8s-netperf with `--search=https://nonexistent.invalid:9200`. Expected: process exits at startup with `failure while connecting to Opensearch`, before any benchmark deployment.
  2. Reachable-then-flaky endpoint → run a normal benchmark with a working `--search`, then induce a DNS/connectivity failure to the OpenSearch endpoint before the run completes (or simulate by pointing at an endpoint that times out only at the indexing step). Expected: benchmark completes, CSV files are present in the working directory, and the indexing failure is logged at `error` level without aborting the process.
  3. Happy path → run a normal benchmark with a working `--search`. Expected: CSVs written and documents indexed as before.
- **Verification done in this PR:** order-of-operations and preflight behavior were verified by code review; `go build ./...` is clean. Live regression of the original 75-minute failure mode was not re-run as part of this change. Reviewers with an OpenSearch endpoint may want to repeat scenarios (1) and (3) above before merge.

### Live verification (partial)

Verified scenario (3), happy path with a reachable OpenSearch endpoint, on a MicroShift single-node cluster. The same patch was cherry-picked onto the user's `microshift_compat` branch and built as `k8s-netperf 0.1.41@3a74608` (cherry-pick of this PR's commit on top of the MicroShift commit; identical code change in the relevant region). Observed log sequence at startup:

```
Starting k8s-netperf (0.1.41@3a74608…)
📁 Creating indexer: opensearch
Connected to : https://...   <-- preflight succeeded before any benchmark work
📒 Reading full-run.yaml file.
... namespace cleanup, deployments, benchmark begins ...
```

Preflight `archive.Connect` runs and completes before config parsing, cleanup, or any pod deployment, confirming the up-front-fail behavior on the success path. Scenarios (1) misconfigured endpoint and (2) reachable-then-flaky endpoint were not exercised live in this iteration; reviewers with an OpenSearch endpoint may still want to confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenSearch integration to automatically index and archive results when a search URL is configured.

* **Refactor**
  * Improved result archival flow with enhanced CSV export and error handling for multiple artifact types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->