### PR TITLE
Skip unsupported workload results and normalize empty-string checks

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -637,7 +637,9 @@ func parseNetworkConfig(jsonFile string) (string, string, error) {
 	return serverIP, clientIP, nil
 }
 
-// executeWorkload executes the workload and returns the result data.
+// executeWorkload runs the workload and returns (result.Data, bool).
+// The bool is true when the result should be recorded and false when
+// the selected driver does not support the configured profile.
 func executeWorkload(nc config.Config,
 	s config.PerfScenarios,
 	hostNet bool,

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -143,7 +143,7 @@ var rootCmd = &cobra.Command{
 			netperf = false
 		}
 		uid := ""
-		if len(id) > 0 {
+		if id != "" {
 			uid = id
 		} else {
 			u := uuid.New()
@@ -159,11 +159,11 @@ var rootCmd = &cobra.Command{
 		}
 
 		searchIndexName := index
-		if len(searchIndex) > 1 {
+		if searchIndex != "" {
 			searchIndexName = searchIndex
 		}
 		var esClient *indexers.Indexer
-		if len(searchURL) > 1 {
+		if searchURL != "" {
 			var err error
 			esClient, err = archive.Connect(searchURL, searchIndexName, true)
 			if err != nil {
@@ -229,7 +229,7 @@ var rootCmd = &cobra.Command{
 
 		pavail := true
 		pcon, _ := metrics.Discover()
-		if len(promURL) > 1 {
+		if promURL != "" {
 			pcon.URL = promURL
 		}
 		pcon.Client, err = prometheus.NewClient(pcon.URL, pcon.Token, "", "", pcon.Verify)
@@ -293,7 +293,7 @@ var rootCmd = &cobra.Command{
 				log.Error(err)
 			}
 			s.KClient = kclient
-			if len(bridge) > 0 {
+			if bridge != "" {
 				err := k8s.DeployNADBridge(s.DClient, bridge)
 				if err != nil {
 					log.Error(err)
@@ -405,18 +405,17 @@ var rootCmd = &cobra.Command{
 				nc.Metric = metric
 				nc.AcrossAZ = acrossAZ
 				// No need to run hostNetwork through Service.
-				var pr result.Data
 				for _, driver := range requestedDrivers {
 					if s.HostNetwork && !nc.Service {
-						pr = executeWorkload(nc, s, true, driver, false)
-						if len(pr.Profile) > 1 {
+						pr, ok := executeWorkload(nc, s, true, driver, false)
+						if ok {
 							sr.Results = append(sr.Results, pr)
 						}
 					}
 					// Skip podNetwork tests if hostNetOnly is enabled
 					if !hostNetOnly {
-						pr = executeWorkload(nc, s, false, driver, false)
-						if len(pr.Profile) > 1 {
+						pr, ok := executeWorkload(nc, s, false, driver, false)
+						if ok {
 							sr.Results = append(sr.Results, pr)
 						}
 					}
@@ -449,15 +448,14 @@ var rootCmd = &cobra.Command{
 				nc.Metric = metric
 				nc.AcrossAZ = acrossAZ
 				// No need to run hostNetwork through Service.
-				var pr result.Data
 				for _, driver := range requestedDrivers {
 					if s.HostNetwork && !nc.Service {
 						log.Info("VM does not support hostNetwork option... skiping")
 					}
 					// Skip podNetwork tests if hostNetOnly is enabled
 					if !hostNetOnly {
-						pr = executeWorkload(nc, s, false, driver, true)
-						if len(pr.Profile) > 1 {
+						pr, ok := executeWorkload(nc, s, false, driver, true)
+						if ok {
 							sr.Results = append(sr.Results, pr)
 						}
 					}
@@ -533,7 +531,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if len(searchURL) > 1 {
+		if searchURL != "" {
 			jdocs, err := archive.BuildDocs(sr, uid)
 			if err != nil {
 				log.Fatal(err)
@@ -643,7 +641,7 @@ func parseNetworkConfig(jsonFile string) (string, string, error) {
 func executeWorkload(nc config.Config,
 	s config.PerfScenarios,
 	hostNet bool,
-	driverName string, virt bool) result.Data {
+	driverName string, virt bool) (result.Data, bool) {
 	serverIP := ""
 	var err error
 	Client := s.Client
@@ -763,7 +761,7 @@ func executeWorkload(nc config.Config,
 	// Check if test is supported
 	if !driver.IsTestSupported() {
 		log.Warnf("Test %s is not supported with driver %s. Skipping.", nc.Profile, npr.Driver)
-		return npr
+		return npr, false
 	}
 	for i := 0; i < nc.Samples; i++ {
 		nr := sample.Sample{}
@@ -806,7 +804,7 @@ func executeWorkload(nc config.Config,
 	npr.ClientNodeInfo = s.ClientNodeInfo
 	npr.ServerNodeInfo = s.ServerNodeInfo
 
-	return npr
+	return npr, true
 }
 
 func main() {


### PR DESCRIPTION
Replace `len(pr.Profile) > 1` with an explicit `(result.Data, bool)` return from `executeWorkload`. Normalize remaining empty-string flag checks to `!= ""`.

Fixes #254

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `len(pr.Profile) > 1` guard at the three `executeWorkload` call sites was intended to filter out results from unsupported driver/profile combinations, but it never worked: `executeWorkload` assigns `npr.Config = nc` before the `IsTestSupported()` early return, so the embedded `Profile` was always populated and the `> 1` check always passed. Unsupported tests were appended to `sr.Results` with empty summary slices and propagated as ghost rows into Prometheus CPU queries, the rendered table, CSV output, and OpenSearch indexing.

`executeWorkload` now returns `(result.Data, bool)`. Callers append only when `ok` is true; unsupported tests still log the existing warning but no longer leak into downstream output.

While here, normalize the other empty-string flag checks to use `x != ""`. The `len(searchIndex) > 1`, `len(searchURL) > 1`, and `len(promURL) > 1` forms silently ignored single-character flag values (latent bug). The `len(id) > 0` and `len(bridge) > 0` forms were behaviorally equivalent to `!= ""` and were normalized for consistency.

## Related Tickets & Documents

- Fixes #254

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- System Under Test: `k8s-netperf` CLI built from this branch.
- `go build ./...` and `go vet ./...` pass cleanly.
- Behavioral check: run with a `netperf.yml` containing a profile/driver pair where `IsTestSupported()` returns false; confirm the existing warning still emits but the unsupported test no longer appears as a row in the rendered table, the CSV, or any indexed OpenSearch document.
- Flag-check verification: pass a 1-character `--prom` / `--search` / `--index` value and confirm it is now honored instead of silently ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UUID assignment for test result identification
  * Improved OpenSearch indexing logic and environment detection for more reliable result submission

* **Refactor**
  * Tests now skip unsupported drivers earlier to avoid irrelevant runs
  * Result collection tightened to include only successful test runs, reducing noise in reports
<!-- end of auto-generated comment: release notes by coderabbit.ai -->