### PR TITLE
Apply gofmt

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -37,45 +37,45 @@ const index = "k8s-netperf"
 const retry = 3
 
 var (
-	cfgfile          string
-	nl               bool
-	clean            bool
-	netperf          bool
-	iperf3           bool
-	uperf            bool
-	ibWriteBw        string
-	udnl2            bool
-	udnl3            bool
-	cudn             string
-	udnPluginBinding string
-	acrossAZ         bool
-	full             bool
-	hostNetOnly      bool
-	pod              bool
-	vm               bool
-	vmimage          string
-	useVirtctl       bool
-	debug            bool
-	bridge           string
-	bridgeNetwork    string
-	bridgeNamespace  string
+	cfgfile           string
+	nl                bool
+	clean             bool
+	netperf           bool
+	iperf3            bool
+	uperf             bool
+	ibWriteBw         string
+	udnl2             bool
+	udnl3             bool
+	cudn              string
+	udnPluginBinding  string
+	acrossAZ          bool
+	full              bool
+	hostNetOnly       bool
+	pod               bool
+	vm                bool
+	vmimage           string
+	useVirtctl        bool
+	debug             bool
+	bridge            string
+	bridgeNetwork     string
+	bridgeNamespace   string
 	sriov             string
 	sriovNodeSelector string
 	macvlan           string
-	promURL          string
-	id               string
-	searchURL        string
-	showMetrics      bool
-	tcpt             float64
-	json             bool
-	version          bool
-	csvArchive       bool
-	searchIndex      string
-	serverIPAddr     string
-	sockets          uint32
-	cores            uint32
-	threads          uint32
-	privileged       bool
+	promURL           string
+	id                string
+	searchURL         string
+	showMetrics       bool
+	tcpt              float64
+	json              bool
+	version           bool
+	csvArchive        bool
+	searchIndex       string
+	serverIPAddr      string
+	sockets           uint32
+	cores             uint32
+	threads           uint32
+	privileged        bool
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cloud-bulldozer/k8s-netperf/pkg/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -537,8 +537,8 @@ func DeploySriovNetwork(dyn *dynamic.DynamicClient, resourceName string) error {
 			},
 			"spec": map[string]interface{}{
 				"networkNamespace": namespace,
-				"resourceName":    resourceName,
-				"ipam":            `{"type": "whereabouts", "range": "192.168.100.0/24"}`,
+				"resourceName":     resourceName,
+				"ipam":             `{"type": "whereabouts", "range": "192.168.100.0/24"}`,
 			},
 		},
 	}

--- a/pkg/k8s/kubevirt.go
+++ b/pkg/k8s/kubevirt.go
@@ -497,7 +497,7 @@ func CreateVMI(client *kubevirtv1.KubevirtV1Client, name string, label map[strin
 				Devices: v1.Devices{
 					NetworkInterfaceMultiQueue: &mutliQ,
 					Disks: []v1.Disk{
-						v1.Disk{
+						{
 							Name: "disk0",
 							DiskDevice: v1.DiskDevice{
 								Disk: &v1.DiskTarget{
@@ -511,7 +511,7 @@ func CreateVMI(client *kubevirtv1.KubevirtV1Client, name string, label map[strin
 			},
 			Networks: networks,
 			Volumes: []v1.Volume{
-				v1.Volume{
+				{
 					Name: "disk0",
 					VolumeSource: v1.VolumeSource{
 						ContainerDisk: &v1.ContainerDiskSource{
@@ -519,7 +519,7 @@ func CreateVMI(client *kubevirtv1.KubevirtV1Client, name string, label map[strin
 						},
 					},
 				},
-				v1.Volume{
+				{
 					Name: "cloudinit",
 					VolumeSource: v1.VolumeSource{
 						CloudInitNoCloud: &v1.CloudInitNoCloudSource{


### PR DESCRIPTION
Apply `gofmt` to the two files flagged by `gofmt -l .`. No semantic change.

Fixes #256

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`gofmt -l .` previously listed `cmd/k8s-netperf/k8s-netperf.go` and `pkg/k8s/kubernetes.go`. After this change `gofmt -l .` produces no output. Specific changes:

- `cmd/k8s-netperf/k8s-netperf.go`: top-level `var` block re-aligned. `sriovNodeSelector` is the longest name in the block and forces the type column one space wider; the surrounding declarations are now adjusted to match.
- `pkg/k8s/kubernetes.go`: imports re-sorted so `k8s.io/api/rbac/v1` precedes `k8s.io/apimachinery/pkg/api/resource`, and the struct literal at line 466 has its map keys aligned.

## Related Tickets & Documents

- Fixes #256

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- System Under Test: `k8s-netperf` source tree built from this branch.
- `gofmt -l .` returns no output.
- `go build ./...` passes.
- `go vet ./...` passes.
- No semantic change; no behavioral test required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and reorganized internal configuration variable declarations for clarity. No behavior or runtime changes.

* **Style**
  * Reformatted imports and adjusted minor layout/formatting within Kubernetes-related modules and VMI/network spec construction. No functional changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/k8s-netperf/pull/257)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/k8s-netperf/pull/257)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->