### PR TITLE
Fix NodeMTU panic on empty Prometheus response

### DIFF
--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -124,10 +124,23 @@ func NodeMTU(conn PromConnect) (int, error) {
 	query := `node_network_mtu_bytes`
 	value, err := conn.Client.QueryRange(query, time.Now().Add(-time.Minute*1), time.Now(), time.Minute)
 	if err != nil {
-		return 0, fmt.Errorf("issue querying openshift mtu info from prometheus")
+		return 0, fmt.Errorf("issue querying openshift mtu info from prometheus: %w", err)
 	}
-	mtu := int(value.(model.Matrix)[0].Values[0].Value)
-	return mtu, nil
+	return extractMTU(value)
+}
+
+func extractMTU(value model.Value) (int, error) {
+	matrix, ok := value.(model.Matrix)
+	if !ok {
+		return 0, fmt.Errorf("unexpected prometheus response type for mtu query: %T", value)
+	}
+	for _, stream := range matrix {
+		if stream == nil || len(stream.Values) == 0 {
+			continue
+		}
+		return int(stream.Values[len(stream.Values)-1].Value), nil
+	}
+	return 0, fmt.Errorf("no mtu samples returned from prometheus")
 }
 
 // QueryNodeCPU will return all the CPU usage information for a given node

--- a/pkg/metrics/system_test.go
+++ b/pkg/metrics/system_test.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestExtractMTUReturnsLatestSample(t *testing.T) {
+	value := model.Matrix{
+		&model.SampleStream{
+			Values: []model.SamplePair{
+				{Value: model.SampleValue(1400)},
+				{Value: model.SampleValue(1500)},
+			},
+		},
+	}
+
+	mtu, err := extractMTU(value)
+	if err != nil {
+		t.Fatalf("extractMTU returned unexpected error: %v", err)
+	}
+	if mtu != 1500 {
+		t.Fatalf("extractMTU returned %d, expected 1500", mtu)
+	}
+}
+
+func TestExtractMTUSkipsEmptyStreams(t *testing.T) {
+	value := model.Matrix{
+		nil,
+		&model.SampleStream{},
+		&model.SampleStream{
+			Values: []model.SamplePair{
+				{Value: model.SampleValue(9000)},
+			},
+		},
+	}
+
+	mtu, err := extractMTU(value)
+	if err != nil {
+		t.Fatalf("extractMTU returned unexpected error: %v", err)
+	}
+	if mtu != 9000 {
+		t.Fatalf("extractMTU returned %d, expected 9000", mtu)
+	}
+}
+
+func TestExtractMTURejectsEmptyResponse(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value model.Value
+	}{
+		{
+			name:  "empty matrix",
+			value: model.Matrix{},
+		},
+		{
+			name: "streams without samples",
+			value: model.Matrix{
+				&model.SampleStream{},
+				&model.SampleStream{Values: []model.SamplePair{}},
+			},
+		},
+		{
+			name:  "unexpected type",
+			value: model.Vector{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := extractMTU(tc.value); err == nil {
+				t.Fatal("extractMTU succeeded, expected an error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace the unchecked `value.(model.Matrix)[0].Values[0]` access in `NodeMTU` with a type-asserted iteration that skips nil and empty streams and returns an error when no usable sample is present. `extractMTU` is extracted as a pure helper so it can be unit-tested without a live Prometheus.

Fixes #247

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`NodeMTU` previously crashed with `panic: runtime error: index out of range [0] with length 0` when Prometheus returned no `node_network_mtu_bytes` samples (see #247). The cast `value.(model.Matrix)[0].Values[0].Value` made three unsafe assumptions: that the response is a `Matrix`, that the matrix has at least one stream, and that the stream has at least one sample.

The fix replaces those assumptions with explicit checks:

- Type-assert with the comma-ok form; return an error if the response is not a `Matrix` (e.g., an empty `Vector`).
- Iterate streams, skipping any that are `nil` or have no samples, and return the most recent sample from the first usable stream. The single-minute query window means any returned MTU value is essentially the current MTU; the most-recent sample is the more representative pick when more than one is present.
- Return an error from the new `no mtu samples returned from prometheus` case, which the existing caller (`cmd/k8s-netperf/k8s-netperf.go:501`) already handles gracefully (`if err == nil { sr.MTU = mtu }` — MTU stays unset, the run completes cleanly).

The matrix handling is extracted into `extractMTU(value model.Value) (int, error)` so it can be unit-tested in isolation. The original Prometheus query error is now wrapped with `%w` so the underlying cause survives.

## Related Tickets & Documents

- Fixes #247

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- System Under Test: `pkg/metrics` package built from this branch.
- `go build ./...`, `go vet ./...`, and `go test ./pkg/metrics/...` all pass.
- New unit tests in `pkg/metrics/system_test.go`:
  - `TestExtractMTUReturnsLatestSample` — happy path with multiple samples returns the most recent value.
  - `TestExtractMTUSkipsEmptyStreams` — `nil` and empty streams are skipped, the first stream with samples is used.
  - `TestExtractMTURejectsEmptyResponse` — three subtests for empty matrix, streams without samples, and a non-Matrix `model.Value` (each must return an error).

cc @sferlin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for system MTU detection failures to include underlying query error details for easier troubleshooting.

* **Tests**
  * Added comprehensive unit tests for MTU extraction validation, covering edge cases and invalid response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->