### PR TITLE
Add Makefile-backed Go verification targets

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -19,8 +19,11 @@ jobs:
 
     - uses: actions/checkout@v6
 
-    - name: Run the golangci-lint
+    - name: Install golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version:  latest
-        args: --timeout=5m
+        version: v2.12.2
+        install-only: true
+
+    - name: Run Go verification
+      run: make verify-go

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,4 +19,4 @@ jobs:
         go-version: 1.23
 
     - name: Test
-      run: go test -v ./...
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,11 @@ verify-ci: verify-fast test
 verify-go: verify-gofmt verify-golangci
 
 verify-gofmt:
-	@files="$$($(GOFMT) -s -l $(SOURCES))"; \
+	@files="$$($(GOFMT) -s -l $(SOURCES))"; status=$$?; \
+	if [ $$status -ne 0 ]; then \
+		echo "Failed to run gofmt check"; \
+		exit $$status; \
+	fi; \
 	if [ -n "$$files" ]; then \
 		echo "Go files are not formatted. Run: make update-gofmt"; \
 		echo "$$files"; \

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ SOURCES := $(shell find . -type f -name '*.go' -not -path './vendor/*' -not -pat
 GIT_COMMIT = $(shell git rev-parse HEAD)
 BUILD_DATE = $(shell date '+%Y-%m-%d-%H:%M:%S')
 CMD_VERSION= github.com/cloud-bulldozer/go-commons/version
-BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-ifeq ($(BRANCH),HEAD)
-	VERSION := $(shell git describe --tags --abbrev=0)
-else
-	VERSION := $(BRANCH)
-endif
+VERSION = $(shell branch="$$(git rev-parse --abbrev-ref HEAD)"; \
+	if [ "$$branch" = "HEAD" ]; then \
+		git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD; \
+	else \
+		echo "$$branch"; \
+	fi)
 
 .PHONY: all build container-build gha-build gha-push clean verify verify-ci verify-fast verify-go verify-gofmt update-gofmt verify-golangci test
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@
 #	- gha-build	- build multi-architecture container image
 #	- gha-push - Push the image & manifest
 #   - clean - remove everything under bin/* directory
+#   - verify - alias for verify-fast (developer quick check)
+#   - verify-fast - static checks only (gofmt + golangci-lint)
+#   - verify-ci - CI bundle: verify-fast + unit tests
+#   - verify-go - Go static checks (gofmt + golangci-lint)
+#   - verify-gofmt - verifies Go files are gofmt -s formatted
+#   - update-gofmt - formats Go files with gofmt -s
+#   - verify-golangci - runs golangci-lint
+#   - test - runs Go unit tests
 
 ARCH=$(shell go env GOARCH)
 BIN = k8s-netperf
@@ -17,7 +25,9 @@ RHEL_VERSION = ubi9
 CONTAINER ?= podman
 CONTAINER_BUILD ?= podman build --force-rm
 CONTAINER_NS ?= quay.io/cloud-bulldozer
-SOURCES := $(shell find . -type f -name "*.go")
+GOFMT ?= gofmt
+GOLANGCI_LINT ?= golangci-lint
+SOURCES := $(shell find . -type f -name '*.go' -not -path './vendor/*' -not -path './bin/*')
 
 # k8s-netperf version
 GIT_COMMIT = $(shell git rev-parse HEAD)
@@ -29,6 +39,8 @@ ifeq ($(BRANCH),HEAD)
 else
 	VERSION := $(BRANCH)
 endif
+
+.PHONY: all build container-build gha-build gha-push clean verify verify-ci verify-fast verify-go verify-gofmt update-gofmt verify-golangci test
 
 all: build container-build
 
@@ -52,6 +64,31 @@ gha-push:
 
 clean:
 	rm -rf bin/$(ARCH)
+
+verify: verify-fast
+
+verify-fast: verify-go
+
+verify-ci: verify-fast test
+
+verify-go: verify-gofmt verify-golangci
+
+verify-gofmt:
+	@files="$$($(GOFMT) -s -l $(SOURCES))"; \
+	if [ -n "$$files" ]; then \
+		echo "Go files are not formatted. Run: make update-gofmt"; \
+		echo "$$files"; \
+		exit 1; \
+	fi
+
+update-gofmt:
+	$(GOFMT) -s -w $(SOURCES)
+
+verify-golangci:
+	$(GOLANGCI_LINT) run --timeout=5m
+
+test:
+	go test -v ./...
 
 $(BIN_PATH): $(SOURCES)
 	GOARCH=$(ARCH) CGO_ENABLED=$(CGO) go build -v -ldflags "-X $(CMD_VERSION).GitCommit=$(GIT_COMMIT) -X $(CMD_VERSION).BuildDate=$(BUILD_DATE) -X $(CMD_VERSION).Version=$(VERSION)" -o $(BIN_PATH) ./cmd/k8s-netperf


### PR DESCRIPTION
Introduce verify, verify-fast, verify-ci, verify-go, verify-gofmt, update-gofmt, verify-golangci, and test Make targets so CI and local workflows run the same commands. Wire go-lint.yml through make verify-go and go-test.yml through make test, and pin golangci-lint to v2.12.2 (previously: latest).

Fixes https://github.com/cloud-bulldozer/k8s-netperf/issues/259

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a Make-based verification ladder modeled on `openshift/microshift`'s Makefile so contributors can run the same commands locally that CI runs.

Make targets:
- `verify` → alias for `verify-fast` (developer quick check)
- `verify-fast` → `verify-go` (static checks only — fast iteration)
- `verify-ci` → `verify-fast` + `test` (full CI bundle)
- `verify-go` → `verify-gofmt` + `verify-golangci`
- `verify-gofmt` → `gofmt -s -l` over the source tree; fails with a pointer to `make update-gofmt` when drift is detected
- `update-gofmt` → `gofmt -s -w` paired write target
- `verify-golangci` → `golangci-lint run --timeout=5m`
- `test` → `go test -v ./...`

Other Makefile changes:
- `GOFMT` and `GOLANGCI_LINT` are now overridable variables.
- `SOURCES` excludes `./vendor/*` and `./bin/*`.
- `.PHONY` declarations added for all new targets.

Workflow changes:
- `go-lint.yml` now installs `golangci-lint` (pinned to `v2.12.2` rather than `latest`) and runs `make verify-go`.
- `go-test.yml` now runs `make test`.

Merge order: https://github.com/cloud-bulldozer/k8s-netperf/pull/257 should merge first. `verify-gofmt` in this PR uses `gofmt -s -l`, which is stricter than the current CI behavior. The formatter cleanup from #257 must land before this PR can pass against `main`.

## Related Tickets & Documents

- Fixes https://github.com/cloud-bulldozer/k8s-netperf/issues/259
- Depends on https://github.com/cloud-bulldozer/k8s-netperf/pull/257 merging first

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- System Under Test: `k8s-netperf` source tree built from this branch.
- `make test` passes locally — 6 unit tests in `testing/netperf_test.go` (TestParseConf, TestParseV2Conf, TestShippingConf, TestMissingParseConf, TestMissingParseV2Conf, TestBadParseConf).
- `make verify-gofmt` correctly fails on a tree with `gofmt -s` drift and prints the offending file list with a pointer to `make update-gofmt`.
- `make update-gofmt` correctly rewrites flagged files in place.
- `make verify-golangci` runs `golangci-lint run --timeout=5m` (same invocation as the previous workflow).
- The full CI bundle (`make verify-ci`) will go green once the pending gofmt cleanup lands on `main`.
- The reworked workflows themselves are exercised by the GitHub Actions runs on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now installs a pinned Go linter and runs unified verification via Make targets.
  * Build automation adds verification and formatting targets and a more consistent version determination approach.
* **Tests**
  * Test workflow standardized to invoke the project's test Make target for consistent test execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/k8s-netperf/pull/260)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->