### PR TITLE
Fix archive CPU collection markers

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -524,8 +524,20 @@ var rootCmd = &cobra.Command{
 		if pavail {
 			for i, npr := range sr.Results {
 				if len(npr.ClientNodeInfo.NodeName) > 0 && len(npr.ServerNodeInfo.NodeName) > 0 {
-					sr.Results[i].ClientMetrics, _ = metrics.QueryNodeCPU(npr.ClientNodeInfo, pcon, npr.StartTime, npr.EndTime)
-					sr.Results[i].ServerMetrics, _ = metrics.QueryNodeCPU(npr.ServerNodeInfo, pcon, npr.StartTime, npr.EndTime)
+					clientCPU, err := metrics.QueryNodeCPU(npr.ClientNodeInfo, pcon, npr.StartTime, npr.EndTime)
+					if err != nil {
+						log.Warnf("Client node CPU metrics were not collected; archiving zero clientCPU with clientCPUCollected=false: node=%s profile=%s messageSize=%d parallelism=%d service=%t sameNode=%t: %v", npr.ClientNodeInfo.NodeName, npr.Profile, npr.MessageSize, npr.Parallelism, npr.Service, npr.SameNode, err)
+					} else {
+						sr.Results[i].ClientMetrics = clientCPU
+						sr.Results[i].ClientCPUCollected = true
+					}
+					serverCPU, err := metrics.QueryNodeCPU(npr.ServerNodeInfo, pcon, npr.StartTime, npr.EndTime)
+					if err != nil {
+						log.Warnf("Server node CPU metrics were not collected; archiving zero serverCPU with serverCPUCollected=false: node=%s profile=%s messageSize=%d parallelism=%d service=%t sameNode=%t: %v", npr.ServerNodeInfo.NodeName, npr.Profile, npr.MessageSize, npr.Parallelism, npr.Service, npr.SameNode, err)
+					} else {
+						sr.Results[i].ServerMetrics = serverCPU
+						sr.Results[i].ServerCPUCollected = true
+					}
 					metrics.VSwitchCPU(npr.ClientNodeInfo, pcon, npr.StartTime, npr.EndTime, &sr.Results[i].ClientMetrics)
 					metrics.VSwitchMem(npr.ClientNodeInfo, pcon, npr.StartTime, npr.EndTime, &sr.Results[i].ClientMetrics)
 					metrics.VSwitchCPU(npr.ServerNodeInfo, pcon, npr.StartTime, npr.EndTime, &sr.Results[i].ServerMetrics)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -19,47 +19,49 @@ const ltcyMetric = "usec"
 
 // Doc struct of the JSON document to be indexed
 type Doc struct {
-	UUID              string           `json:"uuid"`
-	Timestamp         time.Time        `json:"timestamp"`
-	HostNetwork       bool             `json:"hostNetwork"`
-	Driver            string           `json:"driver"`
-	Parallelism       int              `json:"parallelism"`
-	Profile           string           `json:"profile"`
-	Duration          int              `json:"duration"`
-	Service           bool             `json:"service"`
-	Local             bool             `json:"local"`
-	Virt              bool             `json:"virt"`
-	AcrossAZ          bool             `json:"acrossAZ"`
-	Samples           int              `json:"samples"`
-	Messagesize       int              `json:"messageSize"`
-	Burst             int              `json:"burst"`
-	Throughput        float64          `json:"throughput"`
-	Latency           float64          `json:"latency"`
-	TputMetric        string           `json:"tputMetric"`
-	LtcyMetric        string           `json:"ltcyMetric"`
-	TCPRetransmit     float64          `json:"tcpRetransmits"`
-	UDPLossPercent    float64          `json:"udpLossPercent"`
-	ToolVersion       string           `json:"toolVersion"`
-	ToolGitCommit     string           `json:"toolGitCommit"`
-	Metadata          result.Metadata  `json:"metadata"`
-	ServerNodeCPU     metrics.NodeCPU  `json:"serverCPU"`
-	ServerPodCPU      []metrics.PodCPU `json:"serverPods"`
-	ServerPodMem      []metrics.PodMem `json:"serverPodsMem"`
-	ClientNodeCPU     metrics.NodeCPU  `json:"clientCPU"`
-	ClientPodCPU      []metrics.PodCPU `json:"clientPods"`
-	ClientPodMem      []metrics.PodMem `json:"clientPodsMem"`
-	Confidence        []float64        `json:"confidence"`
-	ServerNodeInfo    metrics.NodeInfo `json:"serverNodeInfo"`
-	ClientNodeInfo    metrics.NodeInfo `json:"clientNodeInfo"`
-	ServerVSwitchCpu  float64          `json:"serverVswtichCpu"`
-	ServerVSwitchMem  float64          `json:"serverVswitchMem"`
-	ClientVSwitchCpu  float64          `json:"clientVswtichCpu"`
-	ClientVSwiitchMem float64          `json:"clientVswitchMem"`
-	ExternalServer    bool             `json:"externalServer"`
-	UdnInfo           string           `json:"udnInfo"`
-	BridgeInfo        string           `json:"bridgeInfo"`
-	SriovInfo         string           `json:"sriovInfo"`
-	MacvlanInfo       string           `json:"macvlanInfo"`
+	UUID               string           `json:"uuid"`
+	Timestamp          time.Time        `json:"timestamp"`
+	HostNetwork        bool             `json:"hostNetwork"`
+	Driver             string           `json:"driver"`
+	Parallelism        int              `json:"parallelism"`
+	Profile            string           `json:"profile"`
+	Duration           int              `json:"duration"`
+	Service            bool             `json:"service"`
+	Local              bool             `json:"local"`
+	Virt               bool             `json:"virt"`
+	AcrossAZ           bool             `json:"acrossAZ"`
+	Samples            int              `json:"samples"`
+	Messagesize        int              `json:"messageSize"`
+	Burst              int              `json:"burst"`
+	Throughput         float64          `json:"throughput"`
+	Latency            float64          `json:"latency"`
+	TputMetric         string           `json:"tputMetric"`
+	LtcyMetric         string           `json:"ltcyMetric"`
+	TCPRetransmit      float64          `json:"tcpRetransmits"`
+	UDPLossPercent     float64          `json:"udpLossPercent"`
+	ToolVersion        string           `json:"toolVersion"`
+	ToolGitCommit      string           `json:"toolGitCommit"`
+	Metadata           result.Metadata  `json:"metadata"`
+	ServerNodeCPU      metrics.NodeCPU  `json:"serverCPU"`
+	ServerCPUCollected bool             `json:"serverCPUCollected"`
+	ServerPodCPU       []metrics.PodCPU `json:"serverPods"`
+	ServerPodMem       []metrics.PodMem `json:"serverPodsMem"`
+	ClientNodeCPU      metrics.NodeCPU  `json:"clientCPU"`
+	ClientCPUCollected bool             `json:"clientCPUCollected"`
+	ClientPodCPU       []metrics.PodCPU `json:"clientPods"`
+	ClientPodMem       []metrics.PodMem `json:"clientPodsMem"`
+	Confidence         []float64        `json:"confidence"`
+	ServerNodeInfo     metrics.NodeInfo `json:"serverNodeInfo"`
+	ClientNodeInfo     metrics.NodeInfo `json:"clientNodeInfo"`
+	ServerVSwitchCpu   float64          `json:"serverVswtichCpu"`
+	ServerVSwitchMem   float64          `json:"serverVswitchMem"`
+	ClientVSwitchCpu   float64          `json:"clientVswtichCpu"`
+	ClientVSwiitchMem  float64          `json:"clientVswitchMem"`
+	ExternalServer     bool             `json:"externalServer"`
+	UdnInfo            string           `json:"udnInfo"`
+	BridgeInfo         string           `json:"bridgeInfo"`
+	SriovInfo          string           `json:"sriovInfo"`
+	MacvlanInfo        string           `json:"macvlanInfo"`
 }
 
 // Connect returns a client connected to the desired cluster.
@@ -100,42 +102,44 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 		}
 		c := []float64{lo, hi}
 		d := Doc{
-			UUID:              uuid,
-			Timestamp:         time,
-			ToolVersion:       sr.Version,
-			ToolGitCommit:     sr.GitCommit,
-			Driver:            r.Driver,
-			HostNetwork:       r.HostNetwork,
-			Parallelism:       r.Parallelism,
-			Profile:           r.Profile,
-			Duration:          r.Duration,
-			Virt:              sr.Virt,
-			Samples:           r.Samples,
-			Service:           r.Service,
-			ExternalServer:    r.ExternalServer,
-			Messagesize:       r.MessageSize,
-			Burst:             r.Burst,
-			TputMetric:        r.Metric,
-			LtcyMetric:        ltcyMetric,
-			ServerNodeCPU:     r.ServerMetrics,
-			ClientNodeCPU:     r.ClientMetrics,
-			ServerPodCPU:      r.ServerPodCPU.Results,
-			ServerPodMem:      r.ServerPodMem.MemResults,
-			ClientPodMem:      r.ClientPodMem.MemResults,
-			ClientPodCPU:      r.ClientPodCPU.Results,
-			ClientVSwitchCpu:  r.ClientMetrics.VSwitchCPU,
-			ClientVSwiitchMem: r.ClientMetrics.VSwitchMem,
-			ServerVSwitchCpu:  r.ServerMetrics.VSwitchCPU,
-			ServerVSwitchMem:  r.ServerMetrics.VSwitchMem,
-			Metadata:          sr.Metadata,
-			AcrossAZ:          r.AcrossAZ,
-			Confidence:        c,
-			ClientNodeInfo:    r.ClientNodeInfo,
-			ServerNodeInfo:    r.ServerNodeInfo,
-			UdnInfo:           r.UdnInfo,
-			BridgeInfo:        r.BridgeInfo,
-			SriovInfo:         r.SriovInfo,
-			MacvlanInfo:       r.MacvlanInfo,
+			UUID:               uuid,
+			Timestamp:          time,
+			ToolVersion:        sr.Version,
+			ToolGitCommit:      sr.GitCommit,
+			Driver:             r.Driver,
+			HostNetwork:        r.HostNetwork,
+			Parallelism:        r.Parallelism,
+			Profile:            r.Profile,
+			Duration:           r.Duration,
+			Virt:               sr.Virt,
+			Samples:            r.Samples,
+			Service:            r.Service,
+			ExternalServer:     r.ExternalServer,
+			Messagesize:        r.MessageSize,
+			Burst:              r.Burst,
+			TputMetric:         r.Metric,
+			LtcyMetric:         ltcyMetric,
+			ServerNodeCPU:      r.ServerMetrics,
+			ServerCPUCollected: r.ServerCPUCollected,
+			ClientNodeCPU:      r.ClientMetrics,
+			ClientCPUCollected: r.ClientCPUCollected,
+			ServerPodCPU:       r.ServerPodCPU.Results,
+			ServerPodMem:       r.ServerPodMem.MemResults,
+			ClientPodMem:       r.ClientPodMem.MemResults,
+			ClientPodCPU:       r.ClientPodCPU.Results,
+			ClientVSwitchCpu:   r.ClientMetrics.VSwitchCPU,
+			ClientVSwiitchMem:  r.ClientMetrics.VSwitchMem,
+			ServerVSwitchCpu:   r.ServerMetrics.VSwitchCPU,
+			ServerVSwitchMem:   r.ServerMetrics.VSwitchMem,
+			Metadata:           sr.Metadata,
+			AcrossAZ:           r.AcrossAZ,
+			Confidence:         c,
+			ClientNodeInfo:     r.ClientNodeInfo,
+			ServerNodeInfo:     r.ServerNodeInfo,
+			UdnInfo:            r.UdnInfo,
+			BridgeInfo:         r.BridgeInfo,
+			SriovInfo:          r.SriovInfo,
+			MacvlanInfo:        r.MacvlanInfo,
 		}
 		UDPLossPercent, e := result.Average(r.LossSummary)
 		if e != nil {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1,0 +1,40 @@
+package archive
+
+import (
+	"testing"
+
+	result "github.com/cloud-bulldozer/k8s-netperf/pkg/results"
+)
+
+func TestBuildDocsMapsCPUCollectionFlags(t *testing.T) {
+	docs, err := BuildDocs(result.ScenarioResults{
+		Results: []result.Data{
+			{
+				Driver:             "netperf",
+				ClientCPUCollected: false,
+				ServerCPUCollected: true,
+				ThroughputSummary:  []float64{1},
+				LatencySummary:     []float64{2},
+				LossSummary:        []float64{0},
+				RetransmitSummary:  []float64{0},
+			},
+		},
+	}, "test-uuid")
+	if err != nil {
+		t.Fatalf("BuildDocs returned unexpected error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("BuildDocs returned %d docs, want 1", len(docs))
+	}
+
+	doc, ok := docs[0].(Doc)
+	if !ok {
+		t.Fatalf("BuildDocs returned %T, want archive.Doc", docs[0])
+	}
+	if doc.ClientCPUCollected {
+		t.Fatal("Doc.ClientCPUCollected = true, want false")
+	}
+	if !doc.ServerCPUCollected {
+		t.Fatal("Doc.ServerCPUCollected = false, want true")
+	}
+}

--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/v2/ocp-metadata"
@@ -161,44 +160,115 @@ func extractMTU(value model.Value) (int, error) {
 	return 0, fmt.Errorf("no mtu samples returned from prometheus")
 }
 
-// QueryNodeCPU will return all the CPU usage information for a given node
-func QueryNodeCPU(node NodeInfo, conn PromConnect, start time.Time, end time.Time) (NodeCPU, bool) {
+const (
+	prometheusQueryAttempts       = 3
+	prometheusQueryInitialBackoff = time.Second
+)
+
+// QueryNodeCPU will return all the CPU usage information for a given node.
+func QueryNodeCPU(node NodeInfo, conn PromConnect, start time.Time, end time.Time) (NodeCPU, error) {
+	nodeID := nodeIdentifier(node)
+	if conn.Client == nil {
+		return NodeCPU{}, fmt.Errorf("prometheus client is unavailable for node CPU metrics on %s", nodeID)
+	}
+	// Node CPU has explicit archive validity markers, so retry transient
+	// Prometheus failures before marking the mode breakdown uncollected.
+	return queryPrometheusWithRetry("Node CPU metrics query for "+nodeID, prometheusQueryAttempts, prometheusQueryInitialBackoff, func() (NodeCPU, error) {
+		return queryNodeCPU(node, conn, start, end)
+	})
+}
+
+func queryPrometheusWithRetry[T any](description string, attempts int, initialBackoff time.Duration, query func() (T, error)) (T, error) {
+	var zero T
+	var err error
+	backoff := initialBackoff
+	if attempts < 1 {
+		attempts = 1
+	}
+	for attempt := 1; attempt <= attempts; attempt++ {
+		value, queryErr := query()
+		if queryErr == nil {
+			return value, nil
+		}
+		err = queryErr
+		if attempt < attempts {
+			logging.Warnf("%s failed (attempt %d/%d): %v; retrying in %s", description, attempt, attempts, err, backoff)
+			if backoff > 0 {
+				time.Sleep(backoff)
+			}
+			backoff *= 2
+		}
+	}
+	return zero, err
+}
+
+func queryNodeCPU(node NodeInfo, conn PromConnect, start time.Time, end time.Time) (NodeCPU, error) {
 	cpu := NodeCPU{}
+	nodeID := nodeIdentifier(node)
 	query := nodeCPUQuery(node, conn)
 	logging.Debugf("Prom Query : %s", query)
 	val, err := conn.Client.QueryRange(query, start, end, time.Minute)
 	if err != nil {
-		logging.Error("Issue querying Prometheus")
-		return cpu, false
+		return cpu, fmt.Errorf("querying prometheus for node CPU metrics on %s: %w", nodeID, err)
 	}
-	v := val.(model.Matrix)
+	return extractNodeCPU(val, nodeID)
+}
+
+func extractNodeCPU(val model.Value, nodeID string) (NodeCPU, error) {
+	cpu := NodeCPU{}
+	v, ok := val.(model.Matrix)
+	if !ok {
+		return cpu, fmt.Errorf("unexpected prometheus response type for node CPU metrics on %s: %T", nodeID, val)
+	}
+	if len(v) == 0 {
+		return cpu, fmt.Errorf("no node CPU series returned from prometheus for %s", nodeID)
+	}
+	collected := false
 	for _, s := range v {
-		if strings.Contains(s.Metric.String(), "idle") {
+		if s == nil || len(s.Values) == 0 {
+			continue
+		}
+		switch s.Metric[model.LabelName("mode")] {
+		case "idle":
 			cpu.Idle = avg(s.Values)
-		}
-		if strings.Contains(s.Metric.String(), "steal") {
+			collected = true
+		case "steal":
 			cpu.Steal = avg(s.Values)
-		}
-		if strings.Contains(s.Metric.String(), "system") {
+			collected = true
+		case "system":
 			cpu.System = avg(s.Values)
-		}
-		if strings.Contains(s.Metric.String(), "user") {
+			collected = true
+		case "user":
 			cpu.User = avg(s.Values)
-		}
-		if strings.Contains(s.Metric.String(), "nice") {
+			collected = true
+		case "nice":
 			cpu.Nice = avg(s.Values)
-		}
-		if strings.Contains(s.Metric.String(), "\"irq\"") {
+			collected = true
+		case "irq":
 			cpu.Irq = avg(s.Values)
-		}
-		if strings.Contains(s.Metric.String(), "softirq") {
+			collected = true
+		case "softirq":
 			cpu.Softirq = avg(s.Values)
-		}
-		if strings.Contains(s.Metric.String(), "iowait") {
+			collected = true
+		case "iowait":
 			cpu.Iowait = avg(s.Values)
+			collected = true
 		}
 	}
-	return cpu, true
+	if !collected {
+		return cpu, fmt.Errorf("no usable node CPU samples returned from prometheus for %s", nodeID)
+	}
+	return cpu, nil
+}
+
+func nodeIdentifier(node NodeInfo) string {
+	if node.NodeName != "" {
+		return node.NodeName
+	}
+	if node.IP != "" {
+		return node.IP
+	}
+	return "unknown node"
 }
 
 func nodeCPUQuery(node NodeInfo, conn PromConnect) string {

--- a/pkg/metrics/system_test.go
+++ b/pkg/metrics/system_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -126,5 +127,168 @@ func TestMicroShiftVSwitchQueriesUseNamedprocessMetrics(t *testing.T) {
 	}
 	if !strings.Contains(memQuery, `memtype=~"resident"`) {
 		t.Fatalf("vSwitchMemQuery = %q, want resident memory matcher", memQuery)
+	}
+}
+
+func TestExtractNodeCPUReturnsModeAverages(t *testing.T) {
+	value := model.Matrix{
+		&model.SampleStream{
+			Metric: model.Metric{"mode": "idle"},
+			Values: []model.SamplePair{
+				{Value: model.SampleValue(10)},
+				{Value: model.SampleValue(30)},
+			},
+		},
+		&model.SampleStream{
+			Metric: model.Metric{"mode": "user"},
+			Values: []model.SamplePair{
+				{Value: model.SampleValue(4)},
+				{Value: model.SampleValue(6)},
+			},
+		},
+	}
+
+	cpu, err := extractNodeCPU(value, "node-a")
+	if err != nil {
+		t.Fatalf("extractNodeCPU returned unexpected error: %v", err)
+	}
+	if cpu.Idle != 20 {
+		t.Fatalf("extractNodeCPU idle = %f, expected 20", cpu.Idle)
+	}
+	if cpu.User != 5 {
+		t.Fatalf("extractNodeCPU user = %f, expected 5", cpu.User)
+	}
+}
+
+func TestExtractNodeCPUUsesExactModeLabels(t *testing.T) {
+	value := model.Matrix{
+		&model.SampleStream{
+			Metric: model.Metric{"mode": "nice"},
+			Values: []model.SamplePair{
+				{Value: model.SampleValue(5)},
+			},
+		},
+		&model.SampleStream{
+			Metric: model.Metric{"mode": "guest_nice"},
+			Values: []model.SamplePair{
+				{Value: model.SampleValue(99)},
+			},
+		},
+		&model.SampleStream{
+			Metric: model.Metric{"mode": "irq"},
+			Values: []model.SamplePair{
+				{Value: model.SampleValue(7)},
+			},
+		},
+	}
+
+	cpu, err := extractNodeCPU(value, "node-a")
+	if err != nil {
+		t.Fatalf("extractNodeCPU returned unexpected error: %v", err)
+	}
+	if cpu.Nice != 5 {
+		t.Fatalf("extractNodeCPU nice = %f, expected 5", cpu.Nice)
+	}
+	if cpu.Irq != 7 {
+		t.Fatalf("extractNodeCPU irq = %f, expected 7", cpu.Irq)
+	}
+}
+
+func TestExtractNodeCPURejectsMissingUsableSamples(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value model.Value
+	}{
+		{
+			name:  "empty matrix",
+			value: model.Matrix{},
+		},
+		{
+			name: "streams without samples",
+			value: model.Matrix{
+				&model.SampleStream{},
+				&model.SampleStream{Values: []model.SamplePair{}},
+			},
+		},
+		{
+			name: "series without a known cpu mode",
+			value: model.Matrix{
+				&model.SampleStream{
+					Metric: model.Metric{"mode": "guest"},
+					Values: []model.SamplePair{
+						{Value: model.SampleValue(1)},
+					},
+				},
+			},
+		},
+		{
+			name: "series without an exact known cpu mode",
+			value: model.Matrix{
+				&model.SampleStream{
+					Metric: model.Metric{"mode": "guest_nice"},
+					Values: []model.SamplePair{
+						{Value: model.SampleValue(1)},
+					},
+				},
+			},
+		},
+		{
+			name:  "unexpected type",
+			value: model.Vector{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := extractNodeCPU(tc.value, "node-a"); err == nil {
+				t.Fatal("extractNodeCPU succeeded, expected an error")
+			}
+		})
+	}
+}
+
+func TestQueryPrometheusWithRetrySucceedsAfterTransientErrors(t *testing.T) {
+	attempts := 0
+	expected := NodeCPU{Idle: 42}
+
+	cpu, err := queryPrometheusWithRetry("test query", 3, 0, func() (NodeCPU, error) {
+		attempts++
+		if attempts < 3 {
+			return NodeCPU{}, errors.New("transient failure")
+		}
+		return expected, nil
+	})
+	if err != nil {
+		t.Fatalf("queryPrometheusWithRetry returned unexpected error: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("queryPrometheusWithRetry attempted %d times, want 3", attempts)
+	}
+	if cpu != expected {
+		t.Fatalf("queryPrometheusWithRetry returned %#v, want %#v", cpu, expected)
+	}
+}
+
+func TestQueryPrometheusWithRetryReturnsLastError(t *testing.T) {
+	attempts := 0
+	queryErrs := []error{
+		errors.New("first failure"),
+		errors.New("second failure"),
+		errors.New("last failure"),
+	}
+
+	cpu, err := queryPrometheusWithRetry("test query", 3, 0, func() (NodeCPU, error) {
+		err := queryErrs[attempts]
+		attempts++
+		return NodeCPU{}, err
+	})
+	if err != queryErrs[2] {
+		t.Fatalf("queryPrometheusWithRetry returned error %v, want %v", err, queryErrs[2])
+	}
+	if attempts != 3 {
+		t.Fatalf("queryPrometheusWithRetry attempted %d times, want 3", attempts)
+	}
+	if cpu != (NodeCPU{}) {
+		t.Fatalf("queryPrometheusWithRetry returned %#v, want zero NodeCPU", cpu)
 	}
 }

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -42,16 +42,19 @@ type Data struct {
 	RetransmitSummary []float64
 	ClientMetrics     metrics.NodeCPU
 	ServerMetrics     metrics.NodeCPU
-	ClientPodCPU      metrics.PodValues
-	ClientPodMem      metrics.PodValues
-	ServerPodCPU      metrics.PodValues
-	ServerPodMem      metrics.PodValues
-	ExternalServer    bool
-	UdnInfo           string
-	BridgeInfo        string
-	SriovInfo         string
-	MacvlanInfo       string
-	Virt              bool
+	// CPUCollected covers node CPU mode metrics; vSwitch metrics are collected independently.
+	ClientCPUCollected bool
+	ServerCPUCollected bool
+	ClientPodCPU       metrics.PodValues
+	ClientPodMem       metrics.PodValues
+	ServerPodCPU       metrics.PodValues
+	ServerPodMem       metrics.PodValues
+	ExternalServer     bool
+	UdnInfo            string
+	BridgeInfo         string
+	SriovInfo          string
+	MacvlanInfo        string
+	Virt               bool
 }
 
 // ScenarioResults each scenario could have multiple results


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix archive correctness for node CPU collection:

- Stop silently treating failed node CPU collection as valid zero CPU data. Node CPU collection now returns actionable errors, logs failed client/server CPU collection with scenario context, and stores `clientCPUCollected` / `serverCPUCollected` booleans in indexed docs so dashboards can filter invalid CPU rows.

The CPU CSV schema is left unchanged for compatibility.

## Related Tickets & Documents

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- System Under Test: local k8s-netperf Go test environment using the repository test suite.
- Test steps:
  - `env GOCACHE=/tmp/k8s-netperf-go-build go test ./...`
- Verification:
  - Confirmed archive docs include boolean `clientCPUCollected` / `serverCPUCollected` markers.
  - Confirmed node CPU parsing reports failure for query errors, unexpected response types, empty results, and missing usable CPU samples.
  - Confirmed CPU CSV output does not add new collection-marker columns.

Test result:

```text
ok github.com/cloud-bulldozer/k8s-netperf/pkg/archive
ok github.com/cloud-bulldozer/k8s-netperf/pkg/metrics
ok github.com/cloud-bulldozer/k8s-netperf/testing
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added status indicators in archived results to track whether CPU metrics were successfully collected for client and server nodes

* **Bug Fixes**
  * Improved error visibility by explicitly logging CPU metrics collection failures instead of silently ignoring them
  * Enhanced metric query reliability through automated retry logic for handling transient query failures
  * Refined error messages to include node identification for better troubleshooting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/k8s-netperf/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->