### PR TITLE
Fix archive metadata for local runs and unlabeled-zone clusters

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - s390x
     dir: ./cmd/k8s-netperf/
     ldflags:
-      - -X github.com/cloud-bulldozer/go-commons/version.GitCommit={{.Commit}} -X github.com/cloud-bulldozer/go-commons/version.BuildDate={{.Date}} -X github.com/cloud-bulldozer/go-commons/version.Version={{.Version}}
+      - -X github.com/cloud-bulldozer/go-commons/v2/version.GitCommit={{.Commit}} -X github.com/cloud-bulldozer/go-commons/v2/version.BuildDate={{.Date}} -X github.com/cloud-bulldozer/go-commons/v2/version.Version={{.Version}}
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -443,12 +443,12 @@ var rootCmd = &cobra.Command{
 		sr.Version = cmdVersion.Version
 		sr.GitCommit = cmdVersion.GitCommit
 		// If the client and server needs to be across zones
-		lz, zones, _ := k8s.GetZone(client)
-		nodesInZone := zones[lz]
-		if nodesInZone > 1 {
+		lz, zones, err := k8s.GetZone(client)
+		if s.NodeLocal || err != nil || len(zones) == 0 {
 			acrossAZ = false
 		} else {
-			acrossAZ = true
+			nodesInZone := zones[lz]
+			acrossAZ = nodesInZone <= 1
 		}
 		time.Sleep(5 * time.Second) // Wait some seconds to ensure service is ready
 
@@ -851,6 +851,9 @@ func executeWorkload(nc config.Config,
 		npr.AcrossAZ = true
 	} else {
 		npr.AcrossAZ = nc.AcrossAZ
+	}
+	if npr.SameNode {
+		npr.AcrossAZ = false
 	}
 	npr.StartTime = time.Now()
 	log.Debugf("Executing workloads. hostNetwork is %t, service is %t, externalServer is %t, VM mode is %t", hostNet, nc.Service, npr.ExternalServer, virt)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -114,6 +114,7 @@ func BuildDocs(sr result.ScenarioResults, uuid string) ([]interface{}, error) {
 			Virt:               sr.Virt,
 			Samples:            r.Samples,
 			Service:            r.Service,
+			Local:              r.SameNode,
 			ExternalServer:     r.ExternalServer,
 			Messagesize:        r.MessageSize,
 			Burst:              r.Burst,

--- a/pkg/archive/metadata_test.go
+++ b/pkg/archive/metadata_test.go
@@ -46,3 +46,74 @@ func TestBuildDocsArchivesFullClusterMetadata(t *testing.T) {
 		t.Fatalf("Metadata = %#v, want %#v", doc.Metadata.ClusterMetadata, metadata)
 	}
 }
+
+func TestBuildDocsArchivesResultBooleans(t *testing.T) {
+	tests := []struct {
+		name        string
+		result      result.Data
+		wantLocal   bool
+		wantAcross  bool
+		wantService bool
+		wantHostNet bool
+	}{
+		{
+			name: "all true",
+			result: result.Data{
+				Driver:            "netperf",
+				SameNode:          true,
+				AcrossAZ:          true,
+				Service:           true,
+				HostNetwork:       true,
+				ThroughputSummary: []float64{1},
+				LatencySummary:    []float64{2},
+				LossSummary:       []float64{0},
+				RetransmitSummary: []float64{0},
+			},
+			wantLocal:   true,
+			wantAcross:  true,
+			wantService: true,
+			wantHostNet: true,
+		},
+		{
+			name: "all false",
+			result: result.Data{
+				Driver:            "netperf",
+				ThroughputSummary: []float64{1},
+				LatencySummary:    []float64{2},
+				LossSummary:       []float64{0},
+				RetransmitSummary: []float64{0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			docs, err := BuildDocs(result.ScenarioResults{
+				Results: []result.Data{tt.result},
+			}, "test-uuid")
+			if err != nil {
+				t.Fatalf("BuildDocs returned unexpected error: %v", err)
+			}
+			if len(docs) != 1 {
+				t.Fatalf("BuildDocs returned %d docs, want 1", len(docs))
+			}
+
+			doc, ok := docs[0].(Doc)
+			if !ok {
+				t.Fatalf("BuildDocs returned %T, want archive.Doc", docs[0])
+			}
+			if doc.Local != tt.wantLocal {
+				t.Fatalf("Local = %t, want %t", doc.Local, tt.wantLocal)
+			}
+			if doc.AcrossAZ != tt.wantAcross {
+				t.Fatalf("AcrossAZ = %t, want %t", doc.AcrossAZ, tt.wantAcross)
+			}
+			if doc.Service != tt.wantService {
+				t.Fatalf("Service = %t, want %t", doc.Service, tt.wantService)
+			}
+			if doc.HostNetwork != tt.wantHostNet {
+				t.Fatalf("HostNetwork = %t, want %t", doc.HostNetwork, tt.wantHostNet)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Archive same-node runs as local and prevent local runs from being archived as across AZ when zone discovery is unavailable.

Align GoReleaser ldflags with the go-commons/v2 version package and cover the affected boolean archive mappings.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Resolves three archive issues surfaced by MicroShift ES validation (run UUID `36dc48b5-1da9-48c3-a1cc-16350044bb9b`) but affecting any cluster:

- **Indexed `local=false` on same-node runs.** `BuildDocs` declared `Doc.Local` but never assigned it, so every run on every distribution archived `local=false` regardless of `--local`. Now mapped from `result.Data.SameNode` so OpenSearch/ES documents match the CSV `Same node` column.
- **`acrossAZ=true` on single-node or unlabeled-zone clusters.** The compute path in `executeWorkload`'s caller discarded the `GetZone` error and defaulted to `acrossAZ=true` whenever the zone map was empty. This affects clusters without `topology.kubernetes.io/zone` labels and local runs whose derived archive classification would otherwise be marked across-AZ. Now short-circuits on `s.NodeLocal`, `GetZone` error, or empty zone map. A defensive `if npr.SameNode { npr.AcrossAZ = false }` is also applied per result after the existing `s.AcrossAZ` / `nc.AcrossAZ` precedence block.
- **Empty `toolVersion` / `toolGitCommit` in GoReleaser-built artifacts.** `.goreleaser.yml` injected ldflags into `github.com/cloud-bulldozer/go-commons/version`, but the binary imports `…/go-commons/v2/version` (the Makefile path was already correct). GoReleaser-built artifacts from the current config have blank version metadata. Realigned the ldflag target so released binaries carry usable version and commit metadata.

## Related Tickets & Documents

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- **System Under Test:** single-node MicroShift 4.22.0-rc.2 (`v1.35.3`), `--local=true`, indexing to the production OpenSearch instance. (MicroShift was the validation environment that surfaced these issues; the fixes themselves are distribution-agnostic.)
- **Unit tests:** `go test ./pkg/archive/...` — added `TestBuildDocsArchivesResultBooleans` table-driven test locking the `Local`, `AcrossAZ`, `Service`, and `HostNetwork` archive mappings.
- **End-to-end:** rebuilt the binary with the fix, ran `network-perf-v2` against MicroShift, and confirmed in the resulting indexed documents that `local=true`, `acrossAZ=false`, and `toolVersion` / `toolGitCommit` are populated for all rows. Multi-node zone-labeled runs were checked by code inspection — the new compute-path branch only fires when `s.NodeLocal || err != nil || len(zones) == 0`, so prior behavior is preserved.
- **GoReleaser path:** verified locally via `goreleaser release --snapshot --clean --skip=publish`. The snapshot binary in `dist/k8s-netperf_linux_amd64_v1/` reports `Version`, `Git Commit`, and `Build Date` populated (previously all blank).

## Notes

- Same-node classification wins over explicit `--across` in archived results. If `--local` and `--across` are combined, the run archives `acrossAZ=false` because a same-node run cannot be across availability zones, regardless of requested placement intent.
- Test coverage locks the archive mapping behavior, including `local` and existing boolean fields. The `executeWorkload` same-node guard and the post-`BuildSUT` zone-discovery short-circuit are not unit-tested directly because making those paths independently testable would require a larger command-flow refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-availability zone test logic to properly disable when node-local mode is enabled or zone discovery fails.
  * Ensured test configuration flags (same node, across AZ, service, host network) are correctly archived with results.

* **Tests**
  * Added test coverage for boolean configuration values in archived results.

* **Chores**
  * Updated build configuration for version metadata injection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/k8s-netperf/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->