### PR TITLE
Enable CUDA for GPUDirect support

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -15,6 +15,8 @@ env:
   CONTAINER_REGISTRY: ${{ 'quay.io' }}
   GO_VER: 1.25
   RHEL_VERSION: ubi9
+  PERFTEST_VERSION: perftest-26.01.5
+  CUDA_VERSION: 12-8
 
 jobs:
   build-and-push-container-images:
@@ -48,6 +50,8 @@ jobs:
           make gha-build
         env:
           GO_VER: ${{ env.GO_VER }}
+          PERFTEST_VERSION: ${{ env.PERFTEST_VERSION }}
+          CUDA_VERSION: ${{ env.CUDA_VERSION }}
 
       - name: Push multi-arch Image
         id: push

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ BIN_DIR = bin
 BIN_PATH = $(BIN_DIR)/$(ARCH)/$(BIN)
 CGO = 0
 RHEL_VERSION = ubi9
+PERFTEST_VERSION ?= perftest-26.01.5
+CUDA_VERSION ?= 12-8
 CONTAINER ?= podman
 CONTAINER_BUILD ?= podman build --force-rm
 CONTAINER_NS ?= quay.io/cloud-bulldozer
@@ -50,12 +52,17 @@ container-build: build
 	@echo "Building the container image"
 	$(CONTAINER_BUILD) -f containers/Containerfile \
 		--build-arg RHEL_VERSION=$(RHEL_VERSION) \
+		--build-arg PERFTEST_VERSION=$(PERFTEST_VERSION) \
+		--build-arg CUDA_VERSION=$(CUDA_VERSION) \
 		-t $(CONTAINER_NS)/$(BIN):latest ./containers
 
 gha-build:
 	@echo "Building the container image for GHA"
 	$(CONTAINER_BUILD) -f containers/Containerfile \
-		--build-arg RHEL_VERSION=$(RHEL_VERSION) --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+		--build-arg RHEL_VERSION=$(RHEL_VERSION) \
+		--build-arg PERFTEST_VERSION=$(PERFTEST_VERSION) \
+		--build-arg CUDA_VERSION=$(CUDA_VERSION) \
+		--platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
 		./containers --manifest=$(CONTAINER_NS)/${BIN}:latest
 
 gha-push:

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -1,17 +1,108 @@
 # RHEL_VERSION defined in Makefile
 ARG RHEL_VERSION
+ARG PERFTEST_VERSION=perftest-26.01.5
+ARG CUDA_VERSION=12-8
+
+# ============================================================
+# Stage 1: Build perftest from source (with CUDA on x86_64/aarch64)
+# ============================================================
+FROM registry.access.redhat.com/${RHEL_VERSION}:latest AS perftest-builder
+
+ARG PERFTEST_VERSION
+ARG CUDA_VERSION
+
+RUN dnf install -y --nodocs \
+        make automake autoconf libtool gcc git \
+        rdma-core-devel libibumad-devel pciutils-devel && \
+    dnf clean all
+
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64) \
+            dnf config-manager --add-repo \
+                https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && \
+            dnf install -y --nodocs \
+                cuda-driver-devel-${CUDA_VERSION} \
+                cuda-cudart-devel-${CUDA_VERSION} \
+                cuda-nvcc-${CUDA_VERSION} \
+            ;; \
+        aarch64) \
+            dnf config-manager --add-repo \
+                https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/cuda-rhel9.repo && \
+            dnf install -y --nodocs \
+                cuda-driver-devel-${CUDA_VERSION} \
+                cuda-cudart-devel-${CUDA_VERSION} \
+                cuda-nvcc-${CUDA_VERSION} \
+            ;; \
+    esac && \
+    dnf clean all
+
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64|aarch64) \
+            git clone --branch ${PERFTEST_VERSION} --depth 1 \
+                https://github.com/linux-rdma/perftest.git /tmp/perftest && \
+            cd /tmp/perftest && \
+            ./autogen.sh && \
+            CUDA_H_PATH=/usr/local/cuda/include \
+                ./configure --prefix=/usr --enable-cudart && \
+            make -j$(nproc) && \
+            make install DESTDIR=/install \
+            ;; \
+        ppc64le) \
+            git clone --branch ${PERFTEST_VERSION} --depth 1 \
+                https://github.com/linux-rdma/perftest.git /tmp/perftest && \
+            cd /tmp/perftest && \
+            ./autogen.sh && \
+            ./configure --prefix=/usr && \
+            make -j$(nproc) && \
+            make install DESTDIR=/install \
+            ;; \
+        s390x) \
+            mkdir -p /install \
+            ;; \
+    esac
+
+# ============================================================
+# Stage 2: Final runtime image
+# ============================================================
 FROM registry.access.redhat.com/${RHEL_VERSION}:latest
+
+ARG CUDA_VERSION
 
 COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 
 COPY netperf.diff /tmp/netperf.diff
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
 
-RUN case "$(uname -m)" in \
-        x86_64|aarch64|ppc64le) dnf install -y uperf perftest ;; \
-        s390x) dnf install -y uperf ;; \
+RUN dnf install -y uperf && dnf clean all
+
+COPY --from=perftest-builder /install/ /
+
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64) \
+            dnf config-manager --add-repo \
+                https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && \
+            dnf install -y --nodocs cuda-cudart-${CUDA_VERSION} ;; \
+        aarch64) \
+            dnf config-manager --add-repo \
+                https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/cuda-rhel9.repo && \
+            dnf install -y --nodocs cuda-cudart-${CUDA_VERSION} ;; \
     esac && \
+    dnf install -y rdma-core libibverbs librdmacm && \
     dnf clean all
+
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64|aarch64) \
+            echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/cuda.conf && \
+            ldconfig ;; \
+    esac
 
 RUN dnf install -y --nodocs make automake --enablerepo=centos9 --allowerasing  && \
     dnf install -y --nodocs gcc git bc lksctp-tools-devel --enablerepo=*


### PR DESCRIPTION
The current perftest package was not built with CUDA support:
```
> docker run quay.io/cloud-bulldozer/k8s-netperf ib_write_bw --use-cuda
ib_write_bw: unrecognized option '--use-cuda'
 Invalid Command or flag.
 Please check command line and run again.
```

With this update in the container image, we compile perftest with CUDA support:
```
podman run quay.io/cloud-bulldozer/k8s-netperf:cuda-test ib_write_bw -h | gi cuda
      --use_cuda=<cuda device id> Use CUDA specific device for GPUDirect RDMA testing
      --cuda_mem_type=<value> Set CUDA memory type <value>=0(device,default),1(managed),4(malloc)
      --use_cuda_bus_id=<cuda full BUS id> Use CUDA specific device, based on its full PCIe address, for GPUDirect RDMA testing
```

This will enable GPUDirect support, to be enabled on a followup PR when this merges.

I decided to implement this in the same default image because the CUDA overhead is only 61 MB (about 8% size increase).

cc @dagrayvid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container image build process with support for configurable perftest and CUDA versions
  * Enhanced multi-architecture container builds with optimized compilation for different processor architectures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/k8s-netperf/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->