### PR TITLE
Enable CUDA for GPUDirect support: add --use-cuda flag

### DIFF
--- a/.github/workflows/roce.yml
+++ b/.github/workflows/roce.yml
@@ -119,7 +119,7 @@ jobs:
             '  - curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl"' \
             '  - chmod +x /usr/local/bin/kubectl' \
             '  - kubectl label node kind-control-plane node-role.kubernetes.io/worker=""' \
-            '  - k8s-netperf --config /tmp/roce.yml --privileged --ib-write-bw rxe0:1 --hostNet --local' \
+            '  - k8s-netperf --config /tmp/roce.yml --privileged --ib-write-bw rxe0:1 --hostNet --local --debug' \
             '  - echo "=== RDMA + Podman + Kind + k8s-netperf completed successfully! ==="' \
             '  - echo "✅ RDMA device created"' \
             '  - echo "✅ Podman available"' \

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -44,6 +44,7 @@ var (
 	iperf3            bool
 	uperf             bool
 	ibWriteBw         string
+	useCuda           string
 	udnl2             bool
 	udnl3             bool
 	cudn              string
@@ -110,6 +111,9 @@ var rootCmd = &cobra.Command{
 		}
 		if cudn != "" && (udnl2 || udnl3) {
 			log.Fatal("flags --cudn and --udnl2/--udnl3 are mutually exclusive; please set only one")
+		}
+		if useCuda != "" && !ibWriteBwEnabled {
+			log.Fatalf("😭 --use-cuda requires --ib-write-bw flag")
 		}
 		if ibWriteBwEnabled && (!privileged || !hostNetOnly) {
 			log.Fatalf("😭 ib_write_bw driver requires both --privileged and --hostNet flags")
@@ -241,6 +245,7 @@ var rootCmd = &cobra.Command{
 			MacvlanNetwork:  macvlan,
 			Cudn:            cudn != "",
 			IbWriteBwParams: ibWriteBw,
+			UseCuda:         useCuda,
 			Sockets:         sockets,
 			Cores:           cores,
 			Threads:         threads,
@@ -919,6 +924,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&iperf3, "iperf", false, "Use iperf3 as load driver (default false)")
 	rootCmd.Flags().BoolVar(&uperf, "uperf", false, "Use uperf as load driver (default false)")
 	rootCmd.Flags().StringVar(&ibWriteBw, "ib-write-bw", "", "Use ib_write_bw as load driver, requires nic:gid format (e.g., mlx5_0:0, requires --hostNet)")
+	rootCmd.Flags().StringVar(&useCuda, "use-cuda", "", "CUDA device ID for GPUDirect RDMA testing (requires --ib-write-bw)")
 	rootCmd.Flags().BoolVar(&clean, "clean", true, "Clean-up resources created by k8s-netperf (default true)")
 	rootCmd.Flags().BoolVar(&json, "json", false, "Instead of human-readable output, return JSON to stdout (default false)")
 	rootCmd.Flags().BoolVar(&nl, "local", false, "Run network performance tests with Server-Pods/Client-Pods on the same Node (default false)")

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -112,8 +113,14 @@ var rootCmd = &cobra.Command{
 		if cudn != "" && (udnl2 || udnl3) {
 			log.Fatal("flags --cudn and --udnl2/--udnl3 are mutually exclusive; please set only one")
 		}
-		if useCuda != "" && !ibWriteBwEnabled {
-			log.Fatalf("😭 --use-cuda requires --ib-write-bw flag")
+		if useCuda != "" {
+			useCuda = strings.TrimSpace(useCuda)
+			if !ibWriteBwEnabled {
+				log.Fatalf("😭 --use-cuda requires --ib-write-bw flag")
+			}
+			if cudaID, err := strconv.Atoi(useCuda); err != nil || cudaID < 0 {
+				log.Fatalf("😭 --use-cuda must be a non-negative integer (CUDA device index), got: %s", useCuda)
+			}
 		}
 		if ibWriteBwEnabled && (!privileged || !hostNetOnly) {
 			log.Fatalf("😭 ib_write_bw driver requires both --privileged and --hostNet flags")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,7 @@ type PerfScenarios struct {
 	SriovNetwork        string
 	MacvlanNetwork      string
 	IbWriteBwParams     string
+	UseCuda             string
 	Sockets             uint32
 	Cores               uint32
 	Threads             uint32

--- a/pkg/drivers/ibwritebw.go
+++ b/pkg/drivers/ibwritebw.go
@@ -117,6 +117,9 @@ func (i *ibWriteBw) Run(c *kubernetes.Clientset,
 			Stderr: &stderr,
 		})
 		if err != nil {
+			if outStr := strings.TrimSpace(stdout.String()); outStr != "" {
+				log.Errorf("ib_write_bw output: %s", outStr)
+			}
 			if errStr := strings.TrimSpace(stderr.String()); errStr != "" {
 				log.Errorf("ib_write_bw stderr: %s", errStr)
 			}

--- a/pkg/drivers/ibwritebw.go
+++ b/pkg/drivers/ibwritebw.go
@@ -120,9 +120,6 @@ func (i *ibWriteBw) Run(c *kubernetes.Clientset,
 			if outStr := strings.TrimSpace(stdout.String()); outStr != "" {
 				log.Errorf("ib_write_bw output: %s", outStr)
 			}
-			if errStr := strings.TrimSpace(stderr.String()); errStr != "" {
-				log.Errorf("ib_write_bw stderr: %s", errStr)
-			}
 			return stdout, err
 		}
 	}

--- a/pkg/drivers/ibwritebw.go
+++ b/pkg/drivers/ibwritebw.go
@@ -82,6 +82,10 @@ func (i *ibWriteBw) Run(c *kubernetes.Clientset,
 	// Add duration (ib_write_bw uses -D for duration in seconds)
 	cmd = append(cmd, "-D", fmt.Sprint(nc.Duration))
 
+	if perf.UseCuda != "" {
+		cmd = append(cmd, "--use_cuda="+perf.UseCuda)
+	}
+
 	log.Debug(cmd)
 	//
 	if virt {

--- a/pkg/drivers/ibwritebw.go
+++ b/pkg/drivers/ibwritebw.go
@@ -117,6 +117,9 @@ func (i *ibWriteBw) Run(c *kubernetes.Clientset,
 			Stderr: &stderr,
 		})
 		if err != nil {
+			if errStr := strings.TrimSpace(stderr.String()); errStr != "" {
+				log.Errorf("ib_write_bw stderr: %s", errStr)
+			}
 			return stdout, err
 		}
 	}

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -612,12 +612,18 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 	var netperfVmDataPorts []int32
 	var err error
 
-	// Build SR-IOV resource requests if needed
-	var sriovResources corev1.ResourceList
+	// Build extended resource requests (SR-IOV VFs, GPUs)
+	var extendedResources corev1.ResourceList
 	if s.SriovNetwork != "" {
-		sriovResources = corev1.ResourceList{
+		extendedResources = corev1.ResourceList{
 			corev1.ResourceName("openshift.io/" + s.SriovNetwork): resource.MustParse("1"),
 		}
+	}
+	if s.UseCuda != "" {
+		if extendedResources == nil {
+			extendedResources = corev1.ResourceList{}
+		}
+		extendedResources[corev1.ResourceName("nvidia.com/gpu")] = resource.MustParse("1")
 	}
 
 	// Schedule pods to nodes with role worker=, but not nodes with infra= and workload=
@@ -654,7 +660,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 			Port:               NetperfServerCtlPort,
 			NetworkAnnotations: networkAnnotations,
-			ResourceRequests:   sriovResources,
+			ResourceRequests:   extendedResources,
 			Privileged:         s.Privileged,
 		}
 
@@ -744,7 +750,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 			Port:               NetperfServerCtlPort,
 			NetworkAnnotations: networkAnnotations,
-			ResourceRequests:   sriovResources,
+			ResourceRequests:   extendedResources,
 			Privileged:         s.Privileged,
 		}
 		if z != "" && numNodes > 1 {
@@ -924,7 +930,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		Commands:           [][]string{{"/bin/bash", "-c", "sleep 10000000"}},
 		Port:               NetperfServerCtlPort,
 		NetworkAnnotations: networkAnnotations,
-		ResourceRequests:   sriovResources,
+		ResourceRequests:   extendedResources,
 		Privileged:         s.Privileged,
 	}
 	cdpAcross.PodAntiAffinity = corev1.PodAntiAffinity{
@@ -1095,7 +1101,7 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 		Commands:           dpCommands,
 		Port:               NetperfServerCtlPort,
 		NetworkAnnotations: networkAnnotations,
-		ResourceRequests:   sriovResources,
+		ResourceRequests:   extendedResources,
 		Privileged:         s.Privileged,
 	}
 	if s.NodeLocal {

--- a/pkg/k8s/kubernetes.go
+++ b/pkg/k8s/kubernetes.go
@@ -1061,6 +1061,9 @@ func BuildSUT(client *kubernetes.Clientset, s *config.PerfScenarios) error {
 			}
 		}
 		ibWriteCmd := fmt.Sprintf("stdbuf -oL -eL ib_write_bw -d %s -x %s -F -D %d", device, gid, ibDuration)
+		if s.UseCuda != "" {
+			ibWriteCmd += " --use_cuda=" + s.UseCuda
+		}
 		ibWriteCmd = fmt.Sprintf("while true; do %s; sleep 1; done", ibWriteCmd)
 		dpCommands = append(dpCommands, []string{"/bin/bash", "-c", ibWriteCmd})
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to enable CUDA acceleration for write-bandwidth tests; it validates the device index and only applies when the write-bandwidth test is enabled.
* **Config**
  * Exposed the CUDA option in performance scenario settings so it flows into test runs and server invocation.
* **Bug Fixes**
  * Improved handling and logging of remote test command output.
* **Chores**
  * Test workflow updated to run with debug enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->