### PR TITLE
Enabling VMs for using Bridge option 

### DIFF
--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -798,17 +798,21 @@ func executeWorkload(nc config.Config,
 		log.Debugf("Using SR-IOV network IP: %s", serverIP)
 		npr.SriovInfo = fmt.Sprintf("sriov/%s", s.SriovNetwork)
 	} else if s.BridgeNetwork != "" {
-		// For regular pods, extract bridge IP from network status
-		serverIP, err = k8s.ExtractBridgeIp(s.Server.Items[0], s.BridgeNetwork, s.BridgeNamespace)
-		if err != nil {
-			log.Errorf("Failed to extract bridge IP: %v", err)
-			// Fall back to default IP
-			serverIP = s.Server.Items[0].Status.PodIP
+		if virt {
+			// VMs use static bridge IPs from bridgeNetwork.json (loaded via parseNetworkConfig when --vm --bridge)
+			if s.BridgeServerNetwork == "" {
+				log.Fatal("bridge server network not configured: ensure bridgeNetwork.json is valid when using --vm --bridge")
+			}
+			serverIP = strings.Split(s.BridgeServerNetwork, "/")[0]
+			npr.BridgeInfo = fmt.Sprintf("VM Bridge (%s)", serverIP)
+		} else {
+			serverIP, err = k8s.ExtractBridgeIp(s.Server.Items[0], s.BridgeNetwork, s.BridgeNamespace)
+			if err != nil {
+				log.Fatalf("Failed to extract bridge IP: %v", err)
+			}
+			npr.BridgeInfo = fmt.Sprintf("%s/%s", s.BridgeNamespace, s.BridgeNetwork)
 		}
-		log.Debugf("Using bridge network IP: %s (interface: net1)", serverIP)
-
-		// Set bridge info similar to UdnInfo
-		npr.BridgeInfo = fmt.Sprintf("%s/%s", s.BridgeNamespace, s.BridgeNetwork)
+		log.Debugf("Using bridge network IP: %s", serverIP)
 	} else if s.MacvlanNetwork != "" {
 		serverIP, err = k8s.ExtractMacvlanIp(s.Server.Items[0])
 		if err != nil {
@@ -816,10 +820,6 @@ func executeWorkload(nc config.Config,
 		}
 		log.Debugf("Using MACVLAN network IP: %s", serverIP)
 		npr.MacvlanInfo = fmt.Sprintf("macvlan/%s", s.MacvlanNetwork)
-	} else if s.BridgeServerNetwork != "" {
-		// For VMs, use static bridge IP from JSON config
-		serverIP = strings.Split(s.BridgeServerNetwork, "/")[0]
-		npr.BridgeInfo = fmt.Sprintf("VM Bridge (%s)", serverIP)
 	} else {
 		if virt {
 			serverIP = s.VMServer.Items[0].Status.PodIP


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge-network IP resolution by clearly separating VM-mode and pod-mode logic when bridge networking is enabled.
  * VM-mode now derives the server IP from the configured bridge server address and reports it as “VM Bridge”.
  * Pod-mode bridge IP extraction failures are now treated as fatal (no longer silently falling back to the first server pod IP).
  * Bridge-network debug logging was cleaned up for clearer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->